### PR TITLE
feat(checkbox): add toggle variant option

### DIFF
--- a/src/components/checkbox/checkbox.component.ts
+++ b/src/components/checkbox/checkbox.component.ts
@@ -7,19 +7,21 @@
 import { LitElement, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { styles } from './checkbox.style.js';
-import { CheckboxSize } from './checkbox.types.js';
+import { CheckboxSize, CheckboxVariant } from './checkbox.types.js';
 import { NuralyUIBaseMixin } from '@nuralyui/common/mixins';
 import { CheckboxFocusMixin, CheckboxEventMixin } from './mixins/index.js';
 
 /**
- * Versatile checkbox component with support for indeterminate state, theming, and multiple sizes.
- * 
+ * Versatile checkbox component with support for indeterminate state, theming, multiple sizes, and toggle variant.
+ *
  * @example
  * ```html
  * <nr-checkbox>Check me</nr-checkbox>
  * <nr-checkbox checked>Already checked</nr-checkbox>
  * <nr-checkbox indeterminate>Indeterminate state</nr-checkbox>
  * <nr-checkbox size="large" disabled>Large disabled</nr-checkbox>
+ * <nr-checkbox variant="toggle">Toggle switch</nr-checkbox>
+ * <nr-checkbox variant="toggle" checked>Toggle on</nr-checkbox>
  * ```
  * 
  * @fires nr-change - Dispatched when checkbox state changes
@@ -67,6 +69,22 @@ export class NrCheckboxElement extends CheckboxEventMixin(
     }
   }
   private _size: CheckboxSize = CheckboxSize.Medium;
+
+  /** Checkbox variant (default, toggle) */
+  @property({reflect: true})
+  get variant(): CheckboxVariant {
+    return this._variant;
+  }
+  set variant(value: CheckboxVariant) {
+    const validVariants = [CheckboxVariant.Default, CheckboxVariant.Toggle];
+    if (validVariants.includes(value)) {
+      this._variant = value;
+    } else {
+      console.warn(`Invalid variant value: ${value}. Using default variant: ${CheckboxVariant.Default}`);
+      this._variant = CheckboxVariant.Default;
+    }
+  }
+  private _variant: CheckboxVariant = CheckboxVariant.Default;
 
   /** Form field name */
   @property({type: String})

--- a/src/components/checkbox/checkbox.stories.ts
+++ b/src/components/checkbox/checkbox.stories.ts
@@ -27,6 +27,11 @@ const meta: Meta = {
       options: ['small', 'medium', 'large'],
       description: 'The size of the checkbox',
     },
+    variant: {
+      control: { type: 'select' },
+      options: ['default', 'toggle'],
+      description: 'The visual variant of the checkbox (default or toggle switch)',
+    },
     value: {
       control: { type: 'text' },
       description: 'The value of the checkbox',
@@ -65,6 +70,7 @@ const meta: Meta = {
     disabled: false,
     indeterminate: false,
     size: 'medium',
+    variant: 'default',
     value: 'checkbox-value',
     name: 'checkbox-name',
     label: 'Checkbox Label',
@@ -515,6 +521,174 @@ export const ThemeIntegrationTest: Story = {
           <li>Disabled checkboxes should appear grayed out</li>
           <li>Labels should be clickable and toggle the checkbox</li>
         </ul>
+      </div>
+    </div>
+  `,
+};
+
+// Toggle Variant Stories
+export const Toggle: Story = {
+  args: {
+    variant: 'toggle',
+    label: 'Toggle Switch',
+  },
+  render: (args) => html`
+    <nr-checkbox
+      variant="${args.variant}"
+      ?checked="${args.checked}"
+      ?disabled="${args.disabled}"
+      value="${args.value}"
+      name="${args.name}"
+    >
+      ${args.label}
+    </nr-checkbox>
+  `,
+};
+
+export const ToggleChecked: Story = {
+  args: {
+    variant: 'toggle',
+    checked: true,
+    label: 'Toggle On',
+  },
+  render: (args) => html`
+    <nr-checkbox
+      variant="${args.variant}"
+      ?checked="${args.checked}"
+      ?disabled="${args.disabled}"
+      value="${args.value}"
+      name="${args.name}"
+    >
+      ${args.label}
+    </nr-checkbox>
+  `,
+};
+
+export const ToggleDisabled: Story = {
+  args: {
+    variant: 'toggle',
+    disabled: true,
+    label: 'Disabled Toggle',
+  },
+  render: (args) => html`
+    <nr-checkbox
+      variant="${args.variant}"
+      ?checked="${args.checked}"
+      ?disabled="${args.disabled}"
+      value="${args.value}"
+      name="${args.name}"
+    >
+      ${args.label}
+    </nr-checkbox>
+  `,
+};
+
+export const ToggleDisabledChecked: Story = {
+  args: {
+    variant: 'toggle',
+    disabled: true,
+    checked: true,
+    label: 'Disabled Toggle On',
+  },
+  render: (args) => html`
+    <nr-checkbox
+      variant="${args.variant}"
+      ?checked="${args.checked}"
+      ?disabled="${args.disabled}"
+      value="${args.value}"
+      name="${args.name}"
+    >
+      ${args.label}
+    </nr-checkbox>
+  `,
+};
+
+export const ToggleSizesComparison: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 1.5rem;">
+      <h3>Toggle Size Comparison</h3>
+      <div style="display: flex; flex-direction: column; gap: 1rem;">
+        <div style="display: flex; align-items: center; gap: 2rem;">
+          <nr-checkbox variant="toggle" size="small">Small Toggle</nr-checkbox>
+          <nr-checkbox variant="toggle" size="small" checked>Small On</nr-checkbox>
+        </div>
+        <div style="display: flex; align-items: center; gap: 2rem;">
+          <nr-checkbox variant="toggle" size="medium">Medium Toggle</nr-checkbox>
+          <nr-checkbox variant="toggle" size="medium" checked>Medium On</nr-checkbox>
+        </div>
+        <div style="display: flex; align-items: center; gap: 2rem;">
+          <nr-checkbox variant="toggle" size="large">Large Toggle</nr-checkbox>
+          <nr-checkbox variant="toggle" size="large" checked>Large On</nr-checkbox>
+        </div>
+      </div>
+      <h4>Disabled States</h4>
+      <div style="display: flex; align-items: center; gap: 2rem;">
+        <nr-checkbox variant="toggle" size="small" disabled>Small Disabled</nr-checkbox>
+        <nr-checkbox variant="toggle" size="medium" disabled>Medium Disabled</nr-checkbox>
+        <nr-checkbox variant="toggle" size="large" disabled>Large Disabled</nr-checkbox>
+      </div>
+      <div style="display: flex; align-items: center; gap: 2rem;">
+        <nr-checkbox variant="toggle" size="small" disabled checked>Small On Disabled</nr-checkbox>
+        <nr-checkbox variant="toggle" size="medium" disabled checked>Medium On Disabled</nr-checkbox>
+        <nr-checkbox variant="toggle" size="large" disabled checked>Large On Disabled</nr-checkbox>
+      </div>
+    </div>
+  `,
+};
+
+export const ToggleIndeterminate: Story = {
+  args: {
+    variant: 'toggle',
+    indeterminate: true,
+    label: 'Indeterminate Toggle',
+  },
+  render: (args) => html`
+    <nr-checkbox
+      variant="${args.variant}"
+      ?checked="${args.checked}"
+      ?disabled="${args.disabled}"
+      ?indeterminate="${args.indeterminate}"
+      value="${args.value}"
+      name="${args.name}"
+    >
+      ${args.label}
+    </nr-checkbox>
+  `,
+};
+
+export const ToggleGroup: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+      <h3>Settings</h3>
+      <nr-checkbox variant="toggle" name="settings" value="notifications" checked>Enable notifications</nr-checkbox>
+      <nr-checkbox variant="toggle" name="settings" value="darkMode">Dark mode</nr-checkbox>
+      <nr-checkbox variant="toggle" name="settings" value="autoSave" checked>Auto-save</nr-checkbox>
+      <nr-checkbox variant="toggle" name="settings" value="analytics" disabled>Analytics (coming soon)</nr-checkbox>
+    </div>
+  `,
+};
+
+export const VariantComparison: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 2rem;">
+      <h3>Checkbox vs Toggle Comparison</h3>
+      <div style="display: flex; gap: 4rem;">
+        <div style="display: flex; flex-direction: column; gap: 1rem;">
+          <h4>Default Checkbox</h4>
+          <nr-checkbox>Unchecked</nr-checkbox>
+          <nr-checkbox checked>Checked</nr-checkbox>
+          <nr-checkbox indeterminate>Indeterminate</nr-checkbox>
+          <nr-checkbox disabled>Disabled</nr-checkbox>
+          <nr-checkbox disabled checked>Disabled Checked</nr-checkbox>
+        </div>
+        <div style="display: flex; flex-direction: column; gap: 1rem;">
+          <h4>Toggle Variant</h4>
+          <nr-checkbox variant="toggle">Off</nr-checkbox>
+          <nr-checkbox variant="toggle" checked>On</nr-checkbox>
+          <nr-checkbox variant="toggle" indeterminate>Indeterminate</nr-checkbox>
+          <nr-checkbox variant="toggle" disabled>Disabled</nr-checkbox>
+          <nr-checkbox variant="toggle" disabled checked>Disabled On</nr-checkbox>
+        </div>
       </div>
     </div>
   `,

--- a/src/components/checkbox/checkbox.style.ts
+++ b/src/components/checkbox/checkbox.style.ts
@@ -313,11 +313,129 @@ const checkBoxStyles = css`
     input {
       border-width: 2px;
     }
-    
+
     :host([checked]) input:after,
     :host([indeterminate]) input:after {
       font-weight: 900;
     }
+  }
+
+  /* ========================================
+   * TOGGLE VARIANT STYLES
+   * ========================================
+   * Toggle switch appearance for checkbox
+   */
+
+  /* Toggle variant - track styles */
+  :host([variant='toggle']) input {
+    width: calc(var(--nuraly-checkbox-size-medium) * 2.25);
+    height: calc(var(--nuraly-checkbox-size-medium) * 1.25);
+    border-radius: calc(var(--nuraly-checkbox-size-medium) * 0.625);
+    background-color: var(--nuraly-checkbox-toggle-background, #bfbfbf);
+    border: none;
+  }
+
+  :host([variant='toggle'][size='small']) input {
+    width: calc(var(--nuraly-checkbox-size-small) * 2.25);
+    height: calc(var(--nuraly-checkbox-size-small) * 1.25);
+    border-radius: calc(var(--nuraly-checkbox-size-small) * 0.625);
+  }
+
+  :host([variant='toggle'][size='large']) input {
+    width: calc(var(--nuraly-checkbox-size-large) * 2.25);
+    height: calc(var(--nuraly-checkbox-size-large) * 1.25);
+    border-radius: calc(var(--nuraly-checkbox-size-large) * 0.625);
+  }
+
+  /* Toggle variant - thumb/knob styles */
+  :host([variant='toggle']) input:after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 2px;
+    transform: translateY(-50%);
+    width: calc(var(--nuraly-checkbox-size-medium) * 1.0);
+    height: calc(var(--nuraly-checkbox-size-medium) * 1.0);
+    background-color: var(--nuraly-checkbox-toggle-thumb, #ffffff);
+    border-radius: 50%;
+    transition: var(--nuraly-checkbox-transition);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    border: none;
+  }
+
+  :host([variant='toggle'][size='small']) input:after {
+    width: calc(var(--nuraly-checkbox-size-small) * 1.0);
+    height: calc(var(--nuraly-checkbox-size-small) * 1.0);
+  }
+
+  :host([variant='toggle'][size='large']) input:after {
+    width: calc(var(--nuraly-checkbox-size-large) * 1.0);
+    height: calc(var(--nuraly-checkbox-size-large) * 1.0);
+  }
+
+  /* Toggle variant - checked state */
+  :host([variant='toggle'][checked]) input {
+    background-color: var(--nuraly-checkbox-checked-background);
+  }
+
+  :host([variant='toggle'][checked]) input:after {
+    left: calc(100% - var(--nuraly-checkbox-size-medium) * 1.0 - 2px);
+  }
+
+  :host([variant='toggle'][checked][size='small']) input:after {
+    left: calc(100% - var(--nuraly-checkbox-size-small) * 1.0 - 2px);
+  }
+
+  :host([variant='toggle'][checked][size='large']) input:after {
+    left: calc(100% - var(--nuraly-checkbox-size-large) * 1.0 - 2px);
+  }
+
+  /* Toggle variant - hover state */
+  :host([variant='toggle']:not([disabled]):hover) input {
+    border: none;
+    filter: brightness(0.95);
+  }
+
+  :host([variant='toggle']:not([disabled]):hover[checked]) input {
+    border: none;
+    filter: brightness(1.1);
+  }
+
+  /* Toggle variant - focus state */
+  :host([variant='toggle']) input:focus,
+  :host([variant='toggle']) input:focus-visible {
+    border: none;
+    outline: var(--nuraly-checkbox-focus-outline);
+    outline-offset: 2px;
+  }
+
+  /* Toggle variant - disabled state */
+  :host([variant='toggle'][disabled]) input {
+    background-color: var(--nuraly-checkbox-disabled-background);
+    cursor: not-allowed;
+  }
+
+  :host([variant='toggle'][disabled]) input:after {
+    background-color: var(--nuraly-checkbox-disabled-checkmark-color);
+    box-shadow: none;
+  }
+
+  /* Toggle variant - indeterminate state (show as partially on) */
+  :host([variant='toggle'][indeterminate]:not([checked])) input {
+    background-color: var(--nuraly-checkbox-toggle-background, #bfbfbf);
+  }
+
+  :host([variant='toggle'][indeterminate]:not([checked])) input:after {
+    content: '';
+    left: calc(50% - var(--nuraly-checkbox-size-medium) * 0.5);
+  }
+
+  :host([variant='toggle'][indeterminate][size='small']:not([checked])) input:after {
+    left: calc(50% - var(--nuraly-checkbox-size-small) * 0.5);
+  }
+
+  :host([variant='toggle'][indeterminate][size='large']:not([checked])) input:after {
+    left: calc(50% - var(--nuraly-checkbox-size-large) * 0.5);
   }
 `;
 

--- a/src/components/checkbox/checkbox.types.ts
+++ b/src/components/checkbox/checkbox.types.ts
@@ -3,3 +3,8 @@ export const enum CheckboxSize {
   Medium = 'medium',
   Large = 'large',
 }
+
+export const enum CheckboxVariant {
+  Default = 'default',
+  Toggle = 'toggle',
+}

--- a/src/components/checkbox/index.ts
+++ b/src/components/checkbox/index.ts
@@ -1,1 +1,2 @@
 export * from './checkbox.component.js'
+export * from './checkbox.types.js'


### PR DESCRIPTION
Add a new variant property to the checkbox component that allows it to behave and appear like a toggle switch. The toggle variant features:
- Pill-shaped track with circular thumb/knob
- Smooth animation when toggling on/off
- Support for all size variants (small, medium, large)
- Support for disabled and indeterminate states
- Theme-aware styling with CSS custom properties