### PR TITLE
feat: add editable name to canvas toolbar

### DIFF
--- a/src/components/canvas/templates/toolbar.template.ts
+++ b/src/components/canvas/templates/toolbar.template.ts
@@ -25,6 +25,16 @@ export interface ToolbarTemplateData {
   showChatbot?: boolean;
   onToggleChatbot?: () => void;
   chatbotUnreadCount?: number;
+  // Name editing
+  name?: string;
+  isEditingName?: boolean;
+  onStartEditName?: () => void;
+  onNameInput?: (e: Event) => void;
+  onNameBlur?: (e: FocusEvent) => void;
+  onNameKeydown?: (e: KeyboardEvent) => void;
+  onNamePaste?: (e: ClipboardEvent) => void;
+  onSaveName?: () => void;
+  onCancelEditName?: () => void;
   onModeChange: (mode: CanvasMode) => void;
   onTogglePalette: () => void;
   onZoomIn: () => void;
@@ -64,6 +74,48 @@ function renderChatbotToggle(data: ToolbarTemplateData): TemplateResult | typeof
 }
 
 /**
+ * Render the editable name section in the toolbar
+ */
+function renderToolbarName(data: ToolbarTemplateData): TemplateResult | typeof nothing {
+  if (data.name == null || !data.onStartEditName) return nothing;
+
+  if (data.isEditingName) {
+    return html`
+      <div class="toolbar-divider"></div>
+      <div class="toolbar-name-container">
+        <span
+          class="toolbar-name editing"
+          contenteditable="true"
+          @input=${data.onNameInput}
+          @blur=${data.onNameBlur}
+          @keydown=${data.onNameKeydown}
+          @paste=${data.onNamePaste}
+        ></span>
+        <button class="toolbar-name-action save" @click=${data.onSaveName} title="Save">
+          <nr-icon name="check" size="small"></nr-icon>
+        </button>
+        <button class="toolbar-name-action cancel" @click=${data.onCancelEditName} title="Cancel">
+          <nr-icon name="x" size="small"></nr-icon>
+        </button>
+      </div>
+    `;
+  }
+
+  return html`
+    <div class="toolbar-divider"></div>
+    <button
+      class="toolbar-name-btn"
+      @click=${data.onStartEditName}
+      ?disabled=${data.readonly}
+      title="Click to rename"
+    >
+      <span class="toolbar-name-text">${data.name}</span>
+      <nr-icon name="pencil" size="small" class="toolbar-name-edit-icon"></nr-icon>
+    </button>
+  `;
+}
+
+/**
  * Render the canvas toolbar
  */
 export function renderToolbarTemplate(data: ToolbarTemplateData): TemplateResult | typeof nothing {
@@ -95,6 +147,7 @@ export function renderToolbarTemplate(data: ToolbarTemplateData): TemplateResult
           <nr-icon name="plus" size="small"></nr-icon>
         </button>
       ` : nothing}
+      ${renderToolbarName(data)}
       <div class="toolbar-divider"></div>
       <button
         class="toolbar-btn"

--- a/src/components/canvas/toolbar-name.style.ts
+++ b/src/components/canvas/toolbar-name.style.ts
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright 2024 Nuraly, Laabidi Aymen
+ * SPDX-License-Identifier: MIT
+ */
+
+import { css } from 'lit';
+
+/**
+ * Shared toolbar name editing styles used by both workflow-canvas and whiteboard-canvas.
+ * Extracted to a shared module to avoid CSS duplication across shadow DOM boundaries.
+ */
+export const toolbarNameStyles = css`
+  /* Toolbar name — read-only button */
+  .toolbar-name-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    height: var(--nuraly-size-sm, 32px);
+    padding: 0 10px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--nuraly-border-radius-small, 4px);
+    color: var(--nuraly-color-text-primary, #e5e5e5);
+    cursor: pointer;
+    transition: background var(--nuraly-transition-fast, 0.15s) ease;
+    max-width: 200px;
+    min-width: 0;
+  }
+
+  .toolbar-name-btn:hover {
+    background: var(--nuraly-color-layer-hover-02, rgba(255, 255, 255, 0.1));
+  }
+
+  .toolbar-name-btn:disabled {
+    cursor: default;
+    opacity: 0.7;
+  }
+
+  .toolbar-name-btn:disabled .toolbar-name-edit-icon {
+    display: none;
+  }
+
+  .toolbar-name-text {
+    font-size: 13px;
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .toolbar-name-edit-icon {
+    flex-shrink: 0;
+    opacity: 0;
+    transition: opacity var(--nuraly-transition-fast, 0.15s) ease;
+    --nuraly-icon-size: 12px;
+    color: var(--nuraly-color-text-secondary, #888);
+  }
+
+  .toolbar-name-btn:hover .toolbar-name-edit-icon {
+    opacity: 1;
+  }
+
+  /* Toolbar name — editing state */
+  .toolbar-name-container {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .toolbar-name {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--nuraly-color-text-primary, #e5e5e5);
+    outline: none;
+    padding: 4px 8px;
+    border-radius: var(--nuraly-border-radius-small, 4px);
+    min-width: 60px;
+    max-width: 200px;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+
+  .toolbar-name.editing {
+    background: var(--nuraly-color-layer-hover-02, rgba(255, 255, 255, 0.15));
+    box-shadow: 0 0 0 2px var(--nuraly-color-interactive, #3b82f6);
+  }
+
+  .toolbar-name-action {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    min-height: 44px;
+    min-width: 44px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: var(--nuraly-border-radius-small, 4px);
+    cursor: pointer;
+    transition: background var(--nuraly-transition-fast, 0.15s) ease;
+  }
+
+  .toolbar-name-action.save {
+    color: var(--nuraly-color-success, #22c55e);
+  }
+
+  .toolbar-name-action.save:hover {
+    background: rgba(34, 197, 94, 0.15);
+  }
+
+  .toolbar-name-action.cancel {
+    color: var(--nuraly-color-text-secondary, #888);
+  }
+
+  .toolbar-name-action.cancel:hover {
+    background: var(--nuraly-color-layer-hover-02, rgba(255, 255, 255, 0.1));
+  }
+
+  /* Mobile: always show edit icon, larger touch targets */
+  @media (max-width: 768px) {
+    .toolbar-name-btn {
+      max-width: 120px;
+      padding: 0 8px;
+      min-height: 44px;
+    }
+
+    .toolbar-name-edit-icon {
+      opacity: 1;
+    }
+
+    .toolbar-name {
+      max-width: 120px;
+    }
+  }
+`;

--- a/src/components/canvas/utils/toolbar-name.utils.ts
+++ b/src/components/canvas/utils/toolbar-name.utils.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright 2024 Nuraly, Laabidi Aymen
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Shared toolbar name editing utilities.
+ * Used by both workflow-canvas and whiteboard-canvas to avoid code duplication.
+ */
+
+import type { Workflow } from '../workflow-canvas.types.js';
+
+/**
+ * Canvas component interface for toolbar name editing.
+ * Both workflow-canvas and whiteboard-canvas satisfy this interface.
+ */
+export interface CanvasNameEditable {
+  readonly: boolean;
+  isEditingName: boolean;
+  editedName: string;
+  workflow: Workflow;
+  shadowRoot: ShadowRoot | null;
+  updateComplete: Promise<boolean>;
+  dispatchEvent(event: Event): boolean;
+}
+
+/**
+ * Toolbar name callback set for spreading into ToolbarTemplateData.
+ */
+export interface ToolbarNameCallbacks {
+  onStartEditName: () => void;
+  onNameInput: (e: Event) => void;
+  onNameBlur: (e: FocusEvent) => void;
+  onNameKeydown: (e: KeyboardEvent) => void;
+  onNamePaste: (e: ClipboardEvent) => void;
+  onSaveName: () => void;
+  onCancelEditName: () => void;
+}
+
+/**
+ * Creates toolbar name editing callbacks bound to a canvas component.
+ * Usage: `const nameCallbacks = createToolbarNameCallbacks(this);`
+ */
+export function createToolbarNameCallbacks(canvas: CanvasNameEditable): ToolbarNameCallbacks {
+  function cancel() {
+    canvas.isEditingName = false;
+    canvas.editedName = '';
+  }
+
+  function save() {
+    const trimmed = canvas.editedName.trim();
+    if (!trimmed || trimmed === canvas.workflow.name) {
+      cancel();
+      return;
+    }
+    canvas.workflow = { ...canvas.workflow, name: trimmed };
+    canvas.isEditingName = false;
+    canvas.editedName = '';
+    canvas.dispatchEvent(new CustomEvent('name-changed', {
+      detail: { name: trimmed },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  return {
+    onStartEditName() {
+      if (canvas.readonly) return;
+      canvas.editedName = canvas.workflow.name || '';
+      canvas.isEditingName = true;
+      canvas.updateComplete.then(() => {
+        const el = canvas.shadowRoot?.querySelector('.toolbar-name.editing') as HTMLElement;
+        if (el) {
+          el.textContent = canvas.editedName;
+          el.focus();
+          const range = document.createRange();
+          range.selectNodeContents(el);
+          const sel = globalThis.getSelection();
+          sel?.removeAllRanges();
+          sel?.addRange(range);
+        }
+      });
+    },
+
+    onNameInput(e: Event) {
+      canvas.editedName = (e.target as HTMLElement).textContent?.trim() || '';
+    },
+
+    onNameBlur(e: FocusEvent) {
+      const related = e.relatedTarget as HTMLElement;
+      if (related?.closest('.toolbar-name-action')) return;
+      if (canvas.isEditingName) save();
+    },
+
+    onNameKeydown(e: KeyboardEvent) {
+      if (!canvas.isEditingName) return;
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        save();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        cancel();
+      }
+    },
+
+    onNamePaste(e: ClipboardEvent) {
+      e.preventDefault();
+      const text = e.clipboardData?.getData('text/plain') || '';
+      const sel = globalThis.getSelection();
+      if (sel && sel.rangeCount > 0) {
+        const range = sel.getRangeAt(0);
+        range.deleteContents();
+        range.insertNode(document.createTextNode(text));
+        range.collapse(false);
+      }
+    },
+
+    onSaveName: save,
+    onCancelEditName: cancel,
+  };
+}

--- a/src/components/canvas/whiteboard-canvas.component.ts
+++ b/src/components/canvas/whiteboard-canvas.component.ts
@@ -45,6 +45,7 @@ import {
   TouchController,
   type MarqueeState,
 } from './controllers/index.js';
+import { createToolbarNameCallbacks } from './utils/toolbar-name.utils.js';
 
 // Templates
 import {
@@ -245,6 +246,12 @@ export class WhiteboardCanvasElement extends NuralyUIBaseMixin(LitElement) {
   @state()
   private chatbotUnreadCount = 0;
   private canvasChatbotController: ChatbotCoreController | null = null;
+
+  // Toolbar name editing (non-private — accessed by createToolbarNameCallbacks via CanvasNameEditable)
+  @state()
+  isEditingName = false;
+  @state()
+  editedName = '';
 
   @query('.canvas-wrapper')
   canvasWrapper!: HTMLElement;
@@ -1309,6 +1316,9 @@ export class WhiteboardCanvasElement extends NuralyUIBaseMixin(LitElement) {
       showChatbot: this.showChatbotPanel,
       onToggleChatbot: () => this.toggleChatbotPanel(),
       chatbotUnreadCount: this.chatbotUnreadCount,
+      name: this.workflow.name,
+      isEditingName: this.isEditingName,
+      ...createToolbarNameCallbacks(this),
       onModeChange: (mode) => { this.mode = mode; },
       onTogglePalette: () => { this.showPalette = !this.showPalette; },
       onZoomIn: () => this.viewportController.zoomIn(),

--- a/src/components/canvas/whiteboard-canvas.style.ts
+++ b/src/components/canvas/whiteboard-canvas.style.ts
@@ -1,5 +1,6 @@
 import { css } from 'lit';
 import { chatbotPanelStyles } from './chatbot-panel.style.js';
+import { toolbarNameStyles } from './toolbar-name.style.js';
 
 /**
  * Whiteboard Canvas component styles
@@ -1009,4 +1010,4 @@ export const whiteboardCanvasStyles = css`
 
 `;
 
-export const styles = [whiteboardCanvasStyles, chatbotPanelStyles];
+export const styles = [whiteboardCanvasStyles, chatbotPanelStyles, toolbarNameStyles];

--- a/src/components/canvas/workflow-canvas.component.ts
+++ b/src/components/canvas/workflow-canvas.component.ts
@@ -51,6 +51,7 @@ import {
   TouchController,
   type MarqueeState,
 } from './controllers/index.js';
+import { createToolbarNameCallbacks } from './utils/toolbar-name.utils.js';
 
 // Templates
 import {
@@ -341,6 +342,12 @@ export class WorkflowCanvasElement extends NuralyUIBaseMixin(LitElement) {
   @state()
   private chatbotUnreadCount = 0;
   private canvasChatbotController: ChatbotCoreController | null = null;
+
+  // Toolbar name editing (non-private — accessed by createToolbarNameCallbacks via CanvasNameEditable)
+  @state()
+  isEditingName = false;
+  @state()
+  editedName = '';
 
   // HTTP preview state
   @state()
@@ -1967,6 +1974,9 @@ export class WorkflowCanvasElement extends NuralyUIBaseMixin(LitElement) {
       showChatbot: this.showChatbotPanel,
       onToggleChatbot: () => this.toggleChatbotPanel(),
       chatbotUnreadCount: this.chatbotUnreadCount,
+      name: this.workflow.name,
+      isEditingName: this.isEditingName,
+      ...createToolbarNameCallbacks(this),
       onModeChange: (mode) => { this.mode = mode; },
       onTogglePalette: () => this.togglePalette(),
       onZoomIn: () => this.viewportController.zoomIn(),

--- a/src/components/canvas/workflow-canvas.style.ts
+++ b/src/components/canvas/workflow-canvas.style.ts
@@ -1,5 +1,6 @@
 import { css } from 'lit';
 import { chatbotPanelStyles } from './chatbot-panel.style.js';
+import { toolbarNameStyles } from './toolbar-name.style.js';
 
 /**
  * Workflow Canvas component styles
@@ -2683,4 +2684,4 @@ export const workflowCanvasStyles = css`
 
 `;
 
-export const styles = [workflowCanvasStyles, chatbotPanelStyles];
+export const styles = [workflowCanvasStyles, chatbotPanelStyles, toolbarNameStyles];


### PR DESCRIPTION
## Summary
- Add inline-editable workflow/whiteboard name to the canvas toolbar
- Clicking the name enters edit mode with contenteditable; Enter saves, Escape cancels
- Dispatches `name-changed` CustomEvent for parent components to persist via API
- Shared `toolbar-name.style.ts` avoids CSS duplication across shadow DOM boundaries
- Mobile: 44px min touch targets, always-visible pencil icon on small screens

## Changed files
- `templates/toolbar.template.ts` — added name fields to `ToolbarTemplateData`, `renderToolbarName()` helper
- `toolbar-name.style.ts` — new shared CSS for toolbar name editing
- `workflow-canvas.component.ts` — name editing state, methods, toolbar data wiring
- `whiteboard-canvas.component.ts` — same as above
- `workflow-canvas.style.ts` / `whiteboard-canvas.style.ts` — import shared toolbar-name styles

## Test plan
- [ ] Open workflow editor → toolbar shows workflow name after mode buttons
- [ ] Click name → enters edit mode with blue outline, text selected
- [ ] Type new name → Enter saves, Escape cancels, blur saves
- [ ] Verify `name-changed` event fires with correct detail
- [ ] On mobile (< 768px): pencil icon always visible, 44px touch targets work
- [ ] Read-only mode: name shown but not clickable
- [ ] Repeat all steps on whiteboard editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)