### PR TITLE
refactor: deduplicate base controllers, validation logic, and render utils

### DIFF
--- a/packages/common/src/shared/controllers/base-validation.controller.ts
+++ b/packages/common/src/shared/controllers/base-validation.controller.ts
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright 2023 Nuraly, Laabidi Aymen
+ * SPDX-License-Identifier: MIT
+ */
+
+import { ReactiveControllerHost } from 'lit';
+import { BaseComponentController, BaseHost } from './base.controller.js';
+
+/**
+ * Shared validation rule interface (matches src/shared/validation.types.ts)
+ */
+export interface SharedValidationRule {
+  /** Validation function that returns true if valid */
+  validator: (value: any) => boolean | Promise<boolean>;
+  /** Error/warning message to display if validation fails */
+  message: string;
+  /** Validation level */
+  level?: 'error' | 'warning';
+  /** Whether this rule should block form submission */
+  blocking?: boolean;
+}
+
+/**
+ * Abstract base validation controller that provides shared validation
+ * state management, form integration, and event dispatching.
+ *
+ * Used by input, textarea, select, and radio-group validation controllers
+ * to avoid duplicating common validation patterns.
+ *
+ * @typeParam THost - The component host type
+ */
+export abstract class BaseValidationController<THost extends BaseHost & ReactiveControllerHost>
+  extends BaseComponentController<THost> {
+
+  protected _isValid = true;
+  protected _validationMessage = '';
+  protected _validationState: string = 'pristine';
+  protected _rules: SharedValidationRule[] = [];
+
+  /**
+   * Whether the current value is valid
+   */
+  get isValid(): boolean {
+    return this._isValid;
+  }
+
+  /**
+   * Current validation message
+   */
+  get validationMessage(): string {
+    return this._validationMessage;
+  }
+
+  /**
+   * Current validation state (e.g., 'pristine', 'valid', 'invalid', 'warning', 'pending')
+   */
+  get validationState(): string {
+    return this._validationState;
+  }
+
+  /**
+   * Add a validation rule
+   */
+  addRule(rule: SharedValidationRule): void {
+    this._rules.push(rule);
+    this.requestUpdate();
+  }
+
+  /**
+   * Remove validation rules matching the predicate
+   */
+  removeRule(predicate: (rule: SharedValidationRule) => boolean): void {
+    this._rules = this._rules.filter(rule => !predicate(rule));
+    this.requestUpdate();
+  }
+
+  /**
+   * Clear all validation rules
+   */
+  clearRules(): void {
+    this._rules = [];
+    this.clearValidation();
+  }
+
+  /**
+   * Clear validation state back to pristine
+   */
+  clearValidation(): void {
+    this._isValid = true;
+    this._validationMessage = '';
+    this._validationState = 'pristine';
+    this.requestUpdate();
+    this.dispatchValidationEvent();
+  }
+
+  /**
+   * HTML5 constraint validation API - check validity
+   */
+  checkValidity(): boolean {
+    return this.validate() as boolean;
+  }
+
+  /**
+   * HTML5 constraint validation API - report validity
+   */
+  reportValidity(): boolean {
+    const isValid = this.checkValidity();
+    if (!isValid) {
+      this.dispatchValidationEvent();
+    }
+    return isValid;
+  }
+
+  /**
+   * Dispatch a standardized 'nr-validation' event from the host
+   */
+  protected dispatchValidationEvent(): void {
+    this.dispatchEvent(
+      new CustomEvent('nr-validation', {
+        detail: {
+          isValid: this._isValid,
+          validationMessage: this._validationMessage,
+          validationState: this._validationState,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  /**
+   * Component-specific validation logic.
+   * Subclasses must implement this with their own validation.
+   */
+  abstract validate(): Promise<boolean> | boolean;
+}

--- a/packages/common/src/shared/controllers/base.controller.ts
+++ b/packages/common/src/shared/controllers/base.controller.ts
@@ -1,0 +1,148 @@
+/**
+ * @license
+ * Copyright 2023 Nuraly, Laabidi Aymen
+ * SPDX-License-Identifier: MIT
+ */
+
+import { ReactiveController, ReactiveControllerHost } from 'lit';
+
+/**
+ * Minimal host interface that all component hosts must satisfy
+ */
+export interface BaseHost {
+  requestUpdate(): void;
+}
+
+/**
+ * Error handler interface for consistent error handling across controllers
+ */
+export interface ErrorHandler {
+  handleError(error: Error, context: string): void;
+}
+
+/**
+ * Generic base controller class that implements common functionality
+ * shared across all NuralyUI component controllers.
+ *
+ * Provides lifecycle hooks, error handling, safe update/dispatch,
+ * and utility methods (safeExecute, debounce).
+ *
+ * @typeParam THost - The component host type, must extend BaseHost & ReactiveControllerHost
+ */
+export abstract class BaseComponentController<THost extends BaseHost & ReactiveControllerHost>
+  implements ReactiveController, ErrorHandler {
+  protected _host: THost;
+
+  constructor(host: THost) {
+    this._host = host;
+    host.addController(this);
+  }
+
+  /**
+   * Get the host element
+   */
+  get host(): THost {
+    return this._host;
+  }
+
+  /**
+   * Reactive controller lifecycle - called when host connects
+   */
+  hostConnected(): void {
+    // Override in subclasses if needed
+  }
+
+  /**
+   * Reactive controller lifecycle - called when host disconnects
+   */
+  hostDisconnected(): void {
+    // Override in subclasses if needed
+  }
+
+  /**
+   * Reactive controller lifecycle - called when host updates
+   */
+  hostUpdate(): void {
+    // Override in subclasses if needed
+  }
+
+  /**
+   * Reactive controller lifecycle - called after host updates
+   */
+  hostUpdated(): void {
+    // Override in subclasses if needed
+  }
+
+  /**
+   * Request host update safely
+   */
+  protected requestUpdate(): void {
+    try {
+      this._host.requestUpdate();
+    } catch (error) {
+      this.handleError(error as Error, 'requestUpdate');
+    }
+  }
+
+  /**
+   * Dispatch custom event from host safely
+   */
+  protected dispatchEvent(event: Event): boolean {
+    try {
+      return (this._host as unknown as EventTarget).dispatchEvent(event);
+    } catch (error) {
+      this.handleError(error as Error, 'dispatchEvent');
+      return false;
+    }
+  }
+
+  /**
+   * Handle errors with consistent logging and event dispatching.
+   * Standardizes error events to 'nr-controller-error'.
+   */
+  handleError(error: Error, context: string): void {
+    console.error(`[${this.constructor.name}] Error in ${context}:`, error);
+
+    try {
+      (this._host as unknown as EventTarget).dispatchEvent(
+        new CustomEvent('nr-controller-error', {
+          detail: {
+            error: error.message,
+            context,
+            controller: this.constructor.name,
+          },
+          bubbles: true,
+          composed: true,
+        })
+      );
+    } catch (_) {
+      // Silently fail if event dispatch itself errors
+    }
+  }
+
+  /**
+   * Safely execute a function with error handling
+   */
+  protected safeExecute<T>(fn: () => T, context: string, fallback?: T): T | undefined {
+    try {
+      return fn();
+    } catch (error) {
+      this.handleError(error as Error, context);
+      return fallback;
+    }
+  }
+
+  /**
+   * Debounce utility for controllers
+   */
+  protected debounce<T extends (...args: any[]) => any>(
+    fn: T,
+    wait: number
+  ): (...args: Parameters<T>) => void {
+    let timeout: ReturnType<typeof setTimeout>;
+    return (...args: Parameters<T>) => {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => fn.apply(this, args), wait);
+    };
+  }
+}

--- a/packages/common/src/shared/controllers/index.ts
+++ b/packages/common/src/shared/controllers/index.ts
@@ -1,3 +1,5 @@
+export * from './base.controller.js';
+export * from './base-validation.controller.js';
 export * from './dropdown.interface.js';
 export * from './dropdown.controller.js';
 export * from './theme.controller.js';

--- a/packages/common/src/shared/render-utils.ts
+++ b/packages/common/src/shared/render-utils.ts
@@ -1,0 +1,216 @@
+/**
+ * @license
+ * Copyright 2023 Nuraly, Laabidi Aymen
+ * SPDX-License-Identifier: MIT
+ */
+
+import { html, TemplateResult, nothing } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+
+/**
+ * Options for rendering a clear button
+ */
+export interface ClearButtonOptions {
+  /** Whether clear is allowed on this component */
+  allowClear: boolean;
+  /** Current value (empty value means no clear button shown) */
+  value: any;
+  /** Whether the component is disabled */
+  disabled?: boolean;
+  /** Whether the component is readonly */
+  readonly?: boolean;
+  /** Click handler for the clear action */
+  onClear: (e: Event) => void;
+  /** ARIA label for accessibility */
+  ariaLabel?: string;
+  /** Icon name to use (defaults to 'x') */
+  iconName?: string;
+  /** Icon size (defaults to 'small') */
+  iconSize?: string;
+  /** CSS class for the button */
+  cssClass?: string;
+}
+
+/**
+ * Options for rendering a label
+ */
+export interface LabelOptions {
+  /** CSS class for the label element */
+  cssClass?: string;
+  /** Part attribute for shadow DOM styling */
+  part?: string;
+  /** Associated input element ID */
+  forId?: string;
+  /** CSS class for the required indicator */
+  requiredClass?: string;
+}
+
+/**
+ * Options for rendering a validation message
+ */
+export interface ValidationMessageOptions {
+  /** CSS class for the message container */
+  cssClass?: string;
+  /** The current validation/status state */
+  statusClass?: string;
+  /** Element ID for aria-describedby */
+  id?: string;
+}
+
+/**
+ * Renders a clear button for form components.
+ * Used by input, textarea, and select components.
+ *
+ * @param options - Configuration for the clear button
+ * @returns TemplateResult or nothing if not applicable
+ */
+export function renderClearButton(options: ClearButtonOptions): TemplateResult | typeof nothing {
+  const {
+    allowClear,
+    value,
+    disabled = false,
+    readonly: isReadonly = false,
+    onClear,
+    ariaLabel = 'Clear value',
+    iconName = 'x',
+    iconSize = 'small',
+    cssClass = 'clear-button',
+  } = options;
+
+  if (!allowClear || !value || disabled || isReadonly) return nothing;
+
+  return html`
+    <button
+      class="${cssClass}"
+      type="button"
+      @click=${onClear}
+      aria-label="${ariaLabel}"
+    >
+      <nr-icon name="${iconName}" size="${iconSize}"></nr-icon>
+    </button>
+  `;
+}
+
+/**
+ * Renders a label element for form components.
+ * Used by textarea, colorpicker, and timepicker components.
+ *
+ * @param label - The label text (returns nothing if falsy)
+ * @param required - Whether to show a required indicator
+ * @param options - Additional rendering options
+ * @returns TemplateResult or nothing if no label
+ */
+export function renderLabel(
+  label: string | undefined,
+  required?: boolean,
+  options?: LabelOptions
+): TemplateResult | typeof nothing {
+  if (!label) return nothing;
+
+  const cssClass = options?.cssClass || 'label';
+  const part = options?.part || 'label';
+  const requiredClass = options?.requiredClass || 'required-indicator';
+
+  return html`
+    <label
+      class="${cssClass}"
+      part="${part}"
+      for="${ifDefined(options?.forId)}"
+    >
+      ${label}
+      ${required ? html`<span class="${requiredClass}">*</span>` : nothing}
+    </label>
+  `;
+}
+
+/**
+ * Renders a validation message for form components.
+ * Used by input, textarea, and select components.
+ *
+ * @param message - The validation message (returns nothing if falsy)
+ * @param options - Additional rendering options
+ * @returns TemplateResult or nothing if no message
+ */
+export function renderValidationMessage(
+  message: string | undefined,
+  options?: ValidationMessageOptions
+): TemplateResult | typeof nothing {
+  if (!message) return nothing;
+
+  const cssClass = options?.cssClass || 'validation-message';
+  const statusClass = options?.statusClass || '';
+  const id = options?.id || 'validation-message';
+
+  return html`
+    <div class="${cssClass} ${statusClass}" id="${id}" role="alert" aria-live="polite">
+      ${message}
+    </div>
+  `;
+}
+
+/**
+ * Renders a validation icon based on the validation state.
+ * Used by input and textarea components.
+ *
+ * @param state - The validation state ('error', 'warning', 'success', etc.)
+ * @param hasFeedback - Whether to show feedback (returns nothing if false)
+ * @returns TemplateResult or nothing if no feedback
+ */
+export function renderValidationIcon(
+  state: string | undefined,
+  hasFeedback?: boolean,
+): TemplateResult | typeof nothing {
+  if (!hasFeedback || !state) return nothing;
+
+  let iconName = '';
+  let iconClass = '';
+
+  switch (state) {
+    case 'error':
+      iconName = 'error';
+      iconClass = 'validation-error';
+      break;
+    case 'warning':
+      iconName = 'warning';
+      iconClass = 'validation-warning';
+      break;
+    case 'success':
+      iconName = 'check-circle';
+      iconClass = 'validation-success';
+      break;
+    default:
+      return nothing;
+  }
+
+  return html`
+    <nr-icon
+      class="validation-icon ${iconClass}"
+      name="${iconName}"
+      size="small"
+    ></nr-icon>
+  `;
+}
+
+/**
+ * Renders helper text or validation messages.
+ * Used by colorpicker and timepicker components.
+ *
+ * @param text - Helper text or validation message
+ * @param options - Additional options
+ * @returns TemplateResult or nothing if no text
+ */
+export function renderHelperText(
+  text: string | undefined,
+  options?: { cssClass?: string; isError?: boolean; part?: string }
+): TemplateResult | typeof nothing {
+  if (!text) return nothing;
+
+  const cssClass = options?.cssClass || 'helper-text';
+  const errorClass = options?.isError ? `${cssClass}--error` : '';
+
+  return html`
+    <div class="${cssClass} ${errorClass}" part="${ifDefined(options?.part)}">
+      ${text}
+    </div>
+  `;
+}

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -21,3 +21,6 @@
 
 // Export utility functions
 export * from './shared/utils.js';
+
+// Export render utilities
+export * from './shared/render-utils.js';

--- a/src/components/button/controllers/base.controller.ts
+++ b/src/components/button/controllers/base.controller.ts
@@ -4,96 +4,14 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { ReactiveControllerHost } from 'lit';
 import { ButtonBaseController, ButtonHost, ErrorHandler } from '../interfaces/index.js';
+import { BaseComponentController } from '@nuralyui/common/controllers';
 
 /**
  * Abstract base controller class that implements common functionality
  * for all button component controllers
  */
-export abstract class BaseButtonController implements ButtonBaseController, ReactiveController, ErrorHandler {
-  protected _host: ButtonHost & ReactiveControllerHost;
-
-  constructor(host: ButtonHost & ReactiveControllerHost) {
-    this._host = host;
-    this._host.addController(this);
-  }
-
-  /**
-   * Get the host element
-   */
-  get host(): ButtonHost {
-    return this._host;
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host connects
-   */
-  hostConnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host disconnects
-   */
-  hostDisconnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host updates
-   */
-  hostUpdate(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called after host updates
-   */
-  hostUpdated(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Handle errors in a consistent way across all controllers
-   */
-  handleError(error: Error, context: string): void {
-    console.error(`[ButtonController:${this.constructor.name}] Error in ${context}:`, error);
-    
-    // Dispatch error event for external handling
-    this._host.dispatchEvent(
-      new CustomEvent('nr-button-error', {
-        detail: {
-          error: error.message,
-          context,
-          controller: this.constructor.name,
-        },
-        bubbles: true,
-        composed: true,
-      })
-    );
-  }
-
-  /**
-   * Request host update safely
-   */
-  protected requestUpdate(): void {
-    try {
-      this._host.requestUpdate();
-    } catch (error) {
-      this.handleError(error as Error, 'requestUpdate');
-    }
-  }
-
-  /**
-   * Dispatch custom event safely
-   */
-  protected dispatchEvent(event: Event): boolean {
-    try {
-      return this._host.dispatchEvent(event);
-    } catch (error) {
-      this.handleError(error as Error, 'dispatchEvent');
-      return false;
-    }
-  }
+export abstract class BaseButtonController extends BaseComponentController<ButtonHost & ReactiveControllerHost>
+  implements ButtonBaseController, ErrorHandler {
 }

--- a/src/components/canvas/controllers/base.controller.ts
+++ b/src/components/canvas/controllers/base.controller.ts
@@ -4,86 +4,16 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { ReactiveControllerHost } from 'lit';
 import { CanvasHost, CanvasBaseController, ErrorHandler } from '../interfaces/index.js';
+import { BaseComponentController } from '@nuralyui/common/controllers';
 
 /**
  * Abstract base controller class that implements common functionality
  * for all canvas component controllers
  */
-export abstract class BaseCanvasController implements CanvasBaseController, ReactiveController, ErrorHandler {
-  protected _host: CanvasHost & ReactiveControllerHost;
-
-  constructor(host: CanvasHost & ReactiveControllerHost) {
-    this._host = host;
-    this._host.addController(this);
-  }
-
-  /**
-   * Get the host element
-   */
-  get host(): CanvasHost {
-    return this._host;
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host connects
-   */
-  hostConnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host disconnects
-   */
-  hostDisconnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host updates
-   */
-  hostUpdate(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host has updated
-   */
-  hostUpdated(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Handle errors with consistent logging and optional user feedback
-   */
-  handleError(error: Error, context: string): void {
-    console.error(`[CanvasController] Error in ${context}:`, error);
-
-    this.dispatchEvent(
-      new CustomEvent('canvas-error', {
-        detail: {
-          error,
-          context,
-          timestamp: Date.now(),
-          controller: this.constructor.name,
-        },
-        bubbles: true,
-        composed: true,
-      })
-    );
-  }
-
-  /**
-   * Helper method to dispatch events consistently
-   */
-  protected dispatchEvent(event: CustomEvent): void {
-    try {
-      this._host.dispatchEvent(event);
-    } catch (error) {
-      console.error('[CanvasController] Failed to dispatch event:', error);
-    }
-  }
+export abstract class BaseCanvasController extends BaseComponentController<CanvasHost & ReactiveControllerHost>
+  implements CanvasBaseController, ErrorHandler {
 
   /**
    * Helper to get canvas wrapper element

--- a/src/components/collapse/controllers/accordion.controller.ts
+++ b/src/components/collapse/controllers/accordion.controller.ts
@@ -19,11 +19,6 @@ export interface CollapseAccordionHost extends CollapseControllerHost {
  * Handles accordion behavior (single section open at a time)
  */
 export class CollapseAccordionController extends BaseCollapseController {
-  declare protected host: CollapseAccordionHost;
-
-  constructor(host: CollapseAccordionHost) {
-    super(host);
-  }
 
   /**
    * Handle section toggle with accordion logic

--- a/src/components/collapse/controllers/base.controller.ts
+++ b/src/components/collapse/controllers/base.controller.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { ReactiveControllerHost } from 'lit';
 import { CollapseSection } from '../collapse.type.js';
+import { BaseComponentController } from '@nuralyui/common/controllers';
 
 /**
  * Base controller interface for collapse components
@@ -23,29 +24,7 @@ export interface CollapseControllerHost extends ReactiveControllerHost {
 /**
  * Base controller for collapse component functionality
  */
-export abstract class BaseCollapseController implements ReactiveController {
-  protected host: CollapseControllerHost;
-
-  constructor(host: CollapseControllerHost) {
-    this.host = host;
-    host.addController(this);
-  }
-
-  hostConnected(): void {
-    // Base implementation - can be overridden by subclasses
-  }
-
-  hostDisconnected(): void {
-    // Base implementation - can be overridden by subclasses
-  }
-
-  hostUpdate(): void {
-    // Base implementation - can be overridden by subclasses
-  }
-
-  hostUpdated(): void {
-    // Base implementation - can be overridden by subclasses
-  }
+export abstract class BaseCollapseController extends BaseComponentController<CollapseControllerHost> {
 
   /**
    * Get section by index safely
@@ -63,7 +42,7 @@ export abstract class BaseCollapseController implements ReactiveController {
       this.host.updateSection(index, updates);
       return;
     }
-    
+
     // Fallback to direct update
     const section = this.getSection(index);
     if (section) {
@@ -84,7 +63,7 @@ export abstract class BaseCollapseController implements ReactiveController {
       this.host.updateSections(updates);
       return;
     }
-    
+
     // Fallback to direct batch update
     const newSections = [...this.host.sections];
     let hasChanges = false;

--- a/src/components/colorpicker/color-picker.component.ts
+++ b/src/components/colorpicker/color-picker.component.ts
@@ -8,6 +8,7 @@ import { LitElement, html, nothing, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { NuralyUIBaseMixin } from '@nuralyui/common/mixins';
+import { renderLabel as sharedRenderLabel } from '@nuralyui/common/utils';
 import { INPUT_STATE } from '../input/input.types.js';
 
 // Import child components
@@ -305,13 +306,7 @@ export class ColorPicker extends NuralyUIBaseMixin(LitElement) implements ColorP
    * Renders the label if provided
    */
   private renderLabel() {
-    if (!this.label) return nothing;
-    
-    return html`
-      <label class="color-picker-label">
-        ${this.label}
-      </label>
-    `;
+    return sharedRenderLabel(this.label, false, { cssClass: 'color-picker-label' });
   }
 
   /**

--- a/src/components/colorpicker/controllers/base.controller.ts
+++ b/src/components/colorpicker/controllers/base.controller.ts
@@ -1,64 +1,17 @@
-import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { ReactiveControllerHost } from 'lit';
 import type { ColorPickerHost } from '../interfaces/index.js';
+import { BaseComponentController } from '@nuralyui/common/controllers';
 
 /**
  * Base controller class for all colorpicker controllers
  * Provides common functionality for event dispatching, updates, and error handling
  */
-export abstract class BaseColorPickerController implements ReactiveController {
-  protected host: ColorPickerHost;
-
-  constructor(host: ColorPickerHost) {
-    this.host = host;
-    (host as ReactiveControllerHost).addController(this);
-  }
-
-  /**
-   * Called when the host is connected to the DOM
-   */
-  hostConnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Called when the host is disconnected from the DOM
-   */
-  hostDisconnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Called after the host updates
-   */
-  hostUpdated(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Dispatch a custom event from the host
-   */
-  protected dispatchEvent(event: CustomEvent): void {
-    this.host.dispatchEvent(event);
-  }
-
-  /**
-   * Request an update on the host
-   */
-  protected requestUpdate(): void {
-    this.host.requestUpdate();
-  }
-
-  /**
-   * Handle errors consistently
-   */
-  protected handleError(error: Error, context: string): void {
-    console.error(`[ColorPicker ${context}]:`, error);
-  }
+export abstract class BaseColorPickerController extends BaseComponentController<ColorPickerHost & ReactiveControllerHost> {
 
   /**
    * Find an element within the host's shadow root
    */
   protected findElement(selector: string): HTMLElement | null {
-    return this.host.shadowRoot?.querySelector(selector) || null;
+    return (this._host as any).shadowRoot?.querySelector(selector) || null;
   }
 }

--- a/src/components/dropdown/controllers/base.controller.ts
+++ b/src/components/dropdown/controllers/base.controller.ts
@@ -1,73 +1,13 @@
-import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { ReactiveControllerHost } from 'lit';
 import { DropdownBaseController, DropdownHost, ErrorHandler } from '../interfaces/index.js';
+import { BaseComponentController } from '@nuralyui/common/controllers';
 
 /**
  * Abstract base controller class that implements common functionality
  * for all dropdown component controllers
  */
-export abstract class BaseDropdownController implements DropdownBaseController, ReactiveController, ErrorHandler {
-  protected _host: DropdownHost & ReactiveControllerHost;
-
-  constructor(host: DropdownHost & ReactiveControllerHost) {
-    this._host = host;
-    this._host.addController(this);
-  }
-
-  /**
-   * Get the host element
-   */
-  get host(): DropdownHost {
-    return this._host;
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host connects
-   */
-  hostConnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host disconnects
-   */
-  hostDisconnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host updates
-   */
-  hostUpdate(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called after host updates
-   */
-  hostUpdated(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Request host to update
-   */
-  protected requestUpdate(): void {
-    this._host.requestUpdate();
-  }
-
-  /**
-   * Dispatch a custom event from the host
-   */
-  protected dispatchEvent(event: CustomEvent): boolean {
-    return (this._host as unknown as EventTarget).dispatchEvent(event);
-  }
-
-  /**
-   * Handle errors in a consistent way
-   */
-  handleError(error: Error, context: string): void {
-    console.error(`Dropdown Controller Error in ${context}:`, error);
-  }
+export abstract class BaseDropdownController extends BaseComponentController<DropdownHost & ReactiveControllerHost>
+  implements DropdownBaseController, ErrorHandler {
 
   /**
    * Find elements in the host's shadow DOM

--- a/src/components/input/controllers/base.controller.ts
+++ b/src/components/input/controllers/base.controller.ts
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { ReactiveControllerHost } from 'lit';
+import { BaseComponentController } from '@nuralyui/common/controllers';
+export type { ErrorHandler } from '@nuralyui/common/controllers';
 
 /**
  * Base interface for input controllers
@@ -29,86 +31,8 @@ export interface InputHost {
 }
 
 /**
- * Error handler interface for consistent error handling
- */
-export interface ErrorHandler {
-  handleError(error: Error, context: string): void;
-}
-
-/**
  * Abstract base controller class that implements common functionality
  * for all input component controllers
  */
-export abstract class BaseInputController implements InputBaseController, ReactiveController, ErrorHandler {
-  protected _host: InputHost & ReactiveControllerHost;
-
-  constructor(host: InputHost & ReactiveControllerHost) {
-    this._host = host;
-    this._host.addController(this);
-  }
-
-  /**
-   * Get the host element
-   */
-  get host(): InputHost {
-    return this._host;
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host connects
-   */
-  hostConnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host disconnects
-   */
-  hostDisconnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host updates
-   */
-  hostUpdate(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called after host updates
-   */
-  hostUpdated(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Request host to update
-   */
-  protected requestUpdate(): void {
-    this._host.requestUpdate();
-  }
-
-  /**
-   * Dispatch custom event from host
-   */
-  protected dispatchEvent(event: CustomEvent): boolean {
-    return (this._host as any).dispatchEvent(event);
-  }
-
-  /**
-   * Handle errors consistently across controllers
-   */
-  handleError(error: Error, context: string): void {
-    console.error(`[InputController:${context}]`, error);
-    
-    // Dispatch error event for component consumers
-    this.dispatchEvent(
-      new CustomEvent('nr-controller-error', {
-        detail: { error, context, controller: this.constructor.name },
-        bubbles: true,
-        composed: true,
-      })
-    );
-  }
+export abstract class BaseInputController extends BaseComponentController<InputHost & ReactiveControllerHost> {
 }

--- a/src/components/input/controllers/event.controller.ts
+++ b/src/components/input/controllers/event.controller.ts
@@ -61,7 +61,7 @@ export class InputEventController extends BaseInputController implements EventCo
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   protected get eventHost(): InputEventHost {
-    return this.host as InputEventHost;
+    return this.host as unknown as InputEventHost;
   }
 
   private get inputElement(): HTMLInputElement | null {

--- a/src/components/input/controllers/state.controller.ts
+++ b/src/components/input/controllers/state.controller.ts
@@ -67,7 +67,7 @@ export class ValidationStateController extends BaseInputController implements St
   private _debounceTimer: number | null = null;
 
   protected get stateHost(): ValidationStateHost {
-    return this.host as ValidationStateHost;
+    return this.host as unknown as ValidationStateHost;
   }
 
   /**

--- a/src/components/input/input.component.ts
+++ b/src/components/input/input.component.ts
@@ -402,21 +402,21 @@ export class NrInputElement extends NumberMixin(
    * Add validation rule dynamically
    */
   addRule(rule: ValidationRule): void {
-    this.validationController.addRule(rule);
+    this.validationController.addInputRule(rule);
   }
 
   /**
    * Remove validation rule
    */
   removeRule(predicate: (rule: ValidationRule) => boolean): void {
-    this.validationController.removeRule(predicate);
+    this.validationController.removeInputRule(predicate);
   }
 
   /**
    * Clear all validation rules
    */
   clearRules(): void {
-    this.validationController.clearRules();
+    this.validationController.clearInputRules();
   }
 
   /**

--- a/src/components/menu/controllers/base.controller.ts
+++ b/src/components/menu/controllers/base.controller.ts
@@ -7,32 +7,14 @@
 import type { ReactiveControllerHost } from 'lit';
 import type { NrMenuElement } from '../menu.component.js';
 import type { MenuController } from '../interfaces/index.js';
+import { BaseComponentController } from '@nuralyui/common/controllers';
 
 /**
  * Base controller class providing common functionality for all menu controllers
  * Handles controller lifecycle, error handling, and event dispatching
  */
-export class BaseMenuController implements MenuController {
-  host: NrMenuElement;
-
-  constructor(host: NrMenuElement & ReactiveControllerHost) {
-    this.host = host;
-    host.addController(this);
-  }
-
-  /**
-   * Called when the controller's host element is connected to the DOM
-   */
-  hostConnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Called when the controller's host element is disconnected from the DOM
-   */
-  hostDisconnected(): void {
-    // Override in subclasses if needed
-  }
+export class BaseMenuController extends BaseComponentController<NrMenuElement & ReactiveControllerHost>
+  implements MenuController {
 
   /**
    * Dispatch a custom event from the host element
@@ -40,7 +22,7 @@ export class BaseMenuController implements MenuController {
    * @param detail - Event detail object
    * @param options - Additional event options
    */
-  protected dispatchEvent(
+  protected dispatchMenuEvent(
     eventName: string,
     detail?: any,
     options: Partial<CustomEventInit> = {}
@@ -53,35 +35,11 @@ export class BaseMenuController implements MenuController {
         cancelable: true,
         ...options,
       });
-      return this.host.dispatchEvent(event);
+      return this._host.dispatchEvent(event);
     } catch (error) {
       this.handleError(error as Error, 'dispatchEvent');
       return false;
     }
-  }
-
-  /**
-   * Handle errors consistently across controllers
-   * @param error - The error object
-   * @param context - Context where the error occurred
-   */
-  protected handleError(error: Error, context: string): void {
-    console.error(`[MenuController:${context}]`, error);
-    
-    // Dispatch error event for monitoring
-    this.dispatchEvent('menu-controller-error', {
-      context,
-      error: error.message,
-      stack: error.stack,
-      timestamp: Date.now(),
-    });
-  }
-
-  /**
-   * Request an update of the host element
-   */
-  protected requestUpdate(): void {
-    this.host.requestUpdate();
   }
 
   /**
@@ -96,7 +54,7 @@ export class BaseMenuController implements MenuController {
    * @param pathKey - The path key to search for
    */
   protected getElementByPath(pathKey: string): HTMLElement | null {
-    return this.host.shadowRoot?.querySelector(`[data-path="${pathKey}"]`) || null;
+    return this._host.shadowRoot?.querySelector(`[data-path="${pathKey}"]`) || null;
   }
 
   /**
@@ -104,7 +62,7 @@ export class BaseMenuController implements MenuController {
    */
   protected getAllMenuLinks(): HTMLElement[] {
     return Array.from(
-      this.host.shadowRoot?.querySelectorAll('.menu-link, .sub-menu') || []
+      this._host.shadowRoot?.querySelectorAll('.menu-link, .sub-menu') || []
     );
   }
 
@@ -114,10 +72,10 @@ export class BaseMenuController implements MenuController {
    */
   protected isElementInteractive(element: HTMLElement | null): boolean {
     if (!element) return false;
-    
+
     const isDisabled = element.classList.contains('disabled');
     const isVisible = element.offsetParent !== null;
-    
+
     return !isDisabled && isVisible;
   }
 }

--- a/src/components/menu/controllers/keyboard.controller.ts
+++ b/src/components/menu/controllers/keyboard.controller.ts
@@ -109,7 +109,7 @@ export class KeyboardController extends BaseMenuController implements MenuKeyboa
           break;
       }
 
-      this.dispatchEvent('keyboard-navigation', {
+      this.dispatchMenuEvent('keyboard-navigation', {
         key: event.key,
         currentIndex,
         timestamp: Date.now(),
@@ -227,7 +227,7 @@ export class KeyboardController extends BaseMenuController implements MenuKeyboa
       // Simulate click on the active element
       activeElement.click();
 
-      this.dispatchEvent('keyboard-activation', {
+      this.dispatchMenuEvent('keyboard-activation', {
         key: event.key,
         element: activeElement,
         timestamp: Date.now(),
@@ -247,7 +247,7 @@ export class KeyboardController extends BaseMenuController implements MenuKeyboa
       
       this.stateController.closeAllSubMenus();
 
-      this.dispatchEvent('keyboard-escape', {
+      this.dispatchMenuEvent('keyboard-escape', {
         timestamp: Date.now(),
       });
     } catch (error) {
@@ -277,7 +277,7 @@ export class KeyboardController extends BaseMenuController implements MenuKeyboa
         this.currentFocusIndex = menuItems.indexOf(lastItem);
       }
 
-      this.dispatchEvent('keyboard-home-end', {
+      this.dispatchMenuEvent('keyboard-home-end', {
         key: event.key,
         timestamp: Date.now(),
       });
@@ -330,7 +330,7 @@ export class KeyboardController extends BaseMenuController implements MenuKeyboa
         }
       }
 
-      this.dispatchEvent('keyboard-typeahead', {
+      this.dispatchMenuEvent('keyboard-typeahead', {
         buffer: this.typeAheadBuffer,
         timestamp: Date.now(),
       });

--- a/src/components/menu/controllers/state.controller.ts
+++ b/src/components/menu/controllers/state.controller.ts
@@ -62,7 +62,7 @@ export class StateController extends BaseMenuController implements MenuStateCont
       this.clearHighlights();
       this.requestUpdate();
       
-      this.dispatchEvent('selection-changed', {
+      this.dispatchMenuEvent('selection-changed', {
         path,
         timestamp: Date.now(),
       });
@@ -101,7 +101,7 @@ export class StateController extends BaseMenuController implements MenuStateCont
         this._openSubMenus.add(pathKey);
         this.requestUpdate();
         
-        this.dispatchEvent('submenu-opened', {
+        this.dispatchMenuEvent('submenu-opened', {
           path,
           pathKey,
           timestamp: Date.now(),
@@ -124,7 +124,7 @@ export class StateController extends BaseMenuController implements MenuStateCont
         this._openSubMenus.delete(pathKey);
         this.requestUpdate();
         
-        this.dispatchEvent('submenu-closed', {
+        this.dispatchMenuEvent('submenu-closed', {
           path,
           pathKey,
           timestamp: Date.now(),
@@ -143,7 +143,7 @@ export class StateController extends BaseMenuController implements MenuStateCont
       this._openSubMenus.clear();
       this.requestUpdate();
       
-      this.dispatchEvent('all-submenus-closed', {
+      this.dispatchMenuEvent('all-submenus-closed', {
         timestamp: Date.now(),
       });
     } catch (error) {
@@ -258,7 +258,7 @@ export class StateController extends BaseMenuController implements MenuStateCont
       this._highlightedSubMenus.clear();
       this.requestUpdate();
       
-      this.dispatchEvent('state-reset', {
+      this.dispatchMenuEvent('state-reset', {
         timestamp: Date.now(),
       });
     } catch (error) {

--- a/src/components/radio-group/controllers/validation.controller.ts
+++ b/src/components/radio-group/controllers/validation.controller.ts
@@ -4,18 +4,31 @@
  * SPDX-License-Identifier: MIT
  */
 
+import { ReactiveControllerHost } from 'lit';
+import { BaseValidationController } from '@nuralyui/common/controllers';
 import { ValidationController } from '../interfaces/validation-controller.interface.js';
+
+/**
+ * Host interface for radio group validation
+ */
+interface RadioGroupValidationHost extends ReactiveControllerHost {
+  required: boolean;
+  value: string;
+  name: string;
+  requestUpdate(): void;
+  dispatchEvent(event: Event): boolean;
+}
 
 /**
  * Controller that manages validation logic and form integration for radio groups
  * Implements HTML5 form validation patterns with custom validation support
- * 
+ *
  * Features:
  * - Required field validation
  * - Custom validation message support
  * - Form integration with native validation API
  * - Real-time validation state tracking
- * 
+ *
  * @example
  * ```typescript
  * const controller = new RadioValidationController(hostElement);
@@ -23,129 +36,57 @@ import { ValidationController } from '../interfaces/validation-controller.interf
  * console.log(controller.validationMessage); // Get validation error
  * ```
  */
-export class RadioValidationController implements ValidationController {
-  private host: any; // RadioElement host
-  private _isValid: boolean = true;
-  private _validationMessage: string = '';
-
-  /**
-   * Creates a new RadioValidationController instance
-   * Initializes validation state tracking
-   * 
-   * @param host - The host radio element
-   */
-  constructor(host: any) {
-    this.host = host;
-    host.addController(this);
-  }
-
-  /**
-   * Called when the host element is connected to the DOM
-   * Sets up form integration if the element is within a form
-   */
-  hostConnected() {
-    // Controller connected to host
-  }
-
-  /**
-   * Called when the host element is disconnected from the DOM
-   * Cleans up form event listeners
-   */
-  hostDisconnected() {
-    // Cleanup if needed
-  }
-
-  /**
-   * Checks if the radio group is currently valid
-   * 
-   * @returns True if valid, false if validation errors exist
-   * 
-   * @example
-   * ```typescript
-   * if (!controller.isValid) {
-   *   console.error(controller.validationMessage);
-   * }
-   * ```
-   */
-  get isValid(): boolean {
-    return this._isValid;
-  }
-
-  /**
-   * Gets the current validation error message
-   * 
-   * @returns The validation message string, empty if valid
-   * 
-   * @example
-   * ```typescript
-   * const message = controller.validationMessage;
-   * if (message) displayError(message);
-   * ```
-   */
-  get validationMessage(): string {
-    return this._validationMessage;
-  }
+export class RadioValidationController extends BaseValidationController<RadioGroupValidationHost>
+  implements ValidationController {
 
   /**
    * Validates the current radio group state
    * Checks required field constraints and custom validation rules
-   * 
+   *
    * @returns True if validation passes, false otherwise
    * @fires invalid - When validation fails (for form integration)
-   * 
-   * @example
-   * ```typescript
-   * if (!controller.validate()) {
-   *   form.reportValidity(); // Show validation errors
-   * }
-   * ```
    */
   validate(): boolean {
     const isRequired = this.host.required;
     const selectedValue = this.host.value;
-    
+
     if (isRequired && !selectedValue) {
       this._isValid = false;
       this._validationMessage = 'Please select an option';
-      this.host.requestUpdate();
+      this.requestUpdate();
       return false;
     }
 
     this._isValid = true;
     this._validationMessage = '';
-    this.host.requestUpdate();
+    this.requestUpdate();
     return true;
   }
 
-  // Custom validation
+  /**
+   * Set a custom validation message
+   */
   setCustomValidity(message: string): void {
     this._isValid = !message;
     this._validationMessage = message;
-    this.host.requestUpdate();
+    this.requestUpdate();
   }
 
-  clearValidation(): void {
-    this._isValid = true;
-    this._validationMessage = '';
-    this.host.requestUpdate();
-  }
-
-  // Form integration methods
+  /**
+   * Get form data for form submission
+   */
   getFormData(): { [key: string]: string } {
     const name = this.host.name;
     const value = this.host.value;
     return name ? { [name]: value } : {};
   }
 
-  // Check if the radio group satisfies form constraints
-  checkValidity(): boolean {
-    return this.validate();
-  }
-
-  // Report validation state (similar to native form elements)
-  reportValidity(): boolean {
+  /**
+   * Report validation state (similar to native form elements)
+   */
+  override reportValidity(): boolean {
     const isValid = this.validate();
-    
+
     if (!isValid) {
       // Dispatch invalid event
       const invalidEvent = new CustomEvent('invalid', {
@@ -155,31 +96,37 @@ export class RadioValidationController implements ValidationController {
         bubbles: true,
         composed: true
       });
-      
-      (this.host as any).dispatchEvent(invalidEvent);
+
+      (this._host as unknown as EventTarget).dispatchEvent(invalidEvent);
     }
-    
+
     return isValid;
   }
 
-  // Form reset handler
+  /**
+   * Form reset handler
+   */
   reset(): void {
     this.clearValidation();
   }
 
-  // Get FormData object for native form submission
+  /**
+   * Get FormData object for native form submission
+   */
   getFormDataObject(): FormData | null {
     const name = this.host.name;
     const value = this.host.value;
-    
+
     if (!name || !value) return null;
-    
+
     const formData = new FormData();
     formData.append(name, value);
     return formData;
   }
 
-  // Validate on value change
+  /**
+   * Validate on value change
+   */
   validateOnChange(): void {
     // Auto-validate when value changes if validation was previously invalid
     if (!this._isValid) {

--- a/src/components/select/controllers/base.controller.ts
+++ b/src/components/select/controllers/base.controller.ts
@@ -1,93 +1,11 @@
-import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { ReactiveControllerHost } from 'lit';
 import { SelectBaseController, SelectHost, ErrorHandler } from '../interfaces/index.js';
+import { BaseComponentController } from '@nuralyui/common/controllers';
 
 /**
  * Abstract base controller class that implements common functionality
  * for all select component controllers
  */
-export abstract class BaseSelectController implements SelectBaseController, ReactiveController, ErrorHandler {
-  protected _host: SelectHost & ReactiveControllerHost;
-
-  constructor(host: SelectHost & ReactiveControllerHost) {
-    this._host = host;
-    this._host.addController(this);
-  }
-
-  /**
-   * Get the host element
-   */
-  get host(): SelectHost {
-    return this._host;
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host connects
-   */
-  hostConnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host disconnects
-   */
-  hostDisconnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host updates
-   */
-  hostUpdate(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called after host updates
-   */
-  hostUpdated(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Handle errors in a consistent way across all controllers
-   */
-  handleError(error: Error, context: string): void {
-    console.error(`[SelectController:${this.constructor.name}] Error in ${context}:`, error);
-    
-    // Dispatch error event for external handling
-    this._host.dispatchEvent(
-      new CustomEvent('nr-select-error', {
-        detail: {
-          error: error.message,
-          context,
-          controller: this.constructor.name,
-        },
-        bubbles: true,
-        composed: true,
-      })
-    );
-  }
-
-  /**
-   * Request host update safely
-   */
-  protected requestUpdate(): void {
-    try {
-      this._host.requestUpdate();
-    } catch (error) {
-      this.handleError(error as Error, 'requestUpdate');
-    }
-  }
-
-  /**
-   * Dispatch custom event safely
-   */
-  protected dispatchEvent(event: Event): boolean {
-    try {
-      return this._host.dispatchEvent(event);
-    } catch (error) {
-      this.handleError(error as Error, 'dispatchEvent');
-      return false;
-    }
-  }
+export abstract class BaseSelectController extends BaseComponentController<SelectHost & ReactiveControllerHost>
+  implements SelectBaseController, ErrorHandler {
 }

--- a/src/components/select/select.component.ts
+++ b/src/components/select/select.component.ts
@@ -12,6 +12,7 @@ import { choose } from 'lit/directives/choose.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { NuralyUIBaseMixin } from '@nuralyui/common/mixins';
+import { renderValidationMessage as sharedRenderValidationMessage } from '@nuralyui/common/utils';
 
 // Import types
 import {
@@ -830,13 +831,9 @@ export class HySelectComponent extends NuralyUIBaseMixin(LitElement) implements 
    * Renders validation message when present
    */
   private renderValidationMessage() {
-    const validationMessage = this.validationController.validationMessage;
-    if (!validationMessage) return nothing;
-
-    return html`
-      <div class="validation-message ${this.status}" id="validation-message">
-        ${validationMessage}
-      </div>
-    `;
+    return sharedRenderValidationMessage(
+      this.validationController.validationMessage,
+      { statusClass: this.status }
+    );
   }
 }

--- a/src/components/select/select.constant.ts
+++ b/src/components/select/select.constant.ts
@@ -25,7 +25,7 @@ export const SELECT_EVENTS = {
   /** Fired when validation state changes */
   VALIDATION: 'nr-validation',
   /** Fired when validation error occurs */
-  ERROR: 'nr-select-error',
+  ERROR: 'nr-controller-error',
 } as const;
 
 /**

--- a/src/components/table/controllers/base.controller.ts
+++ b/src/components/table/controllers/base.controller.ts
@@ -4,96 +4,14 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { ReactiveControllerHost } from 'lit';
 import { TableBaseController, TableHost, ErrorHandler } from '../interfaces/index.js';
+import { BaseComponentController } from '@nuralyui/common/controllers';
 
 /**
  * Abstract base controller class that implements common functionality
  * for all table component controllers
  */
-export abstract class BaseTableController implements TableBaseController, ReactiveController, ErrorHandler {
-  protected _host: TableHost & ReactiveControllerHost;
-
-  constructor(host: TableHost & ReactiveControllerHost) {
-    this._host = host;
-    this._host.addController(this);
-  }
-
-  /**
-   * Get the host element
-   */
-  get host(): TableHost {
-    return this._host;
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host connects
-   */
-  hostConnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host disconnects
-   */
-  hostDisconnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host updates
-   */
-  hostUpdate(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called after host updates
-   */
-  hostUpdated(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Handle errors in a consistent way across all controllers
-   */
-  handleError(error: Error, context: string): void {
-    console.error(`[TableController:${this.constructor.name}] Error in ${context}:`, error);
-    
-    // Dispatch error event for external handling
-    this._host.dispatchEvent(
-      new CustomEvent('nr-table-error', {
-        detail: {
-          error: error.message,
-          context,
-          controller: this.constructor.name,
-        },
-        bubbles: true,
-        composed: true,
-      })
-    );
-  }
-
-  /**
-   * Request host update safely
-   */
-  protected requestUpdate(): void {
-    try {
-      this._host.requestUpdate();
-    } catch (error) {
-      this.handleError(error as Error, 'requestUpdate');
-    }
-  }
-
-  /**
-   * Dispatch custom event safely
-   */
-  protected dispatchEvent(event: Event): boolean {
-    try {
-      return this._host.dispatchEvent(event);
-    } catch (error) {
-      this.handleError(error as Error, 'dispatchEvent');
-      return false;
-    }
-  }
+export abstract class BaseTableController extends BaseComponentController<TableHost & ReactiveControllerHost>
+  implements TableBaseController, ErrorHandler {
 }

--- a/src/components/tabs/controllers/base.controller.ts
+++ b/src/components/tabs/controllers/base.controller.ts
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { ReactiveControllerHost } from 'lit';
 import { TabItem } from '../tabs.types.js';
+import { BaseComponentController } from '@nuralyui/common/controllers';
+export type { ErrorHandler } from '@nuralyui/common/controllers';
 
 /**
  * Base interface for tabs host element
@@ -35,90 +37,11 @@ export interface TabsBaseController {
 }
 
 /**
- * Error handler interface for controllers
- */
-export interface ErrorHandler {
-  handleError(error: Error, context: string): void;
-}
-
-/**
  * Abstract base controller class that implements common functionality
  * for all tabs component controllers
  */
-export abstract class BaseTabsController implements TabsBaseController, ReactiveController, ErrorHandler {
-  protected _host: TabsHost & ReactiveControllerHost;
-
-  constructor(host: TabsHost & ReactiveControllerHost) {
-    this._host = host;
-    this._host.addController(this);
-  }
-
-  /**
-   * Get the host element
-   */
-  get host(): TabsHost {
-    return this._host;
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host connects
-   */
-  hostConnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host disconnects
-   */
-  hostDisconnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host updates
-   */
-  hostUpdate(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host has updated
-   */
-  hostUpdated(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Handle errors with consistent logging and optional user feedback
-   */
-  handleError(error: Error, context: string): void {
-    console.error(`[TabsController] Error in ${context}:`, error);
-    
-    // Dispatch error event for handling by parent component
-    this.dispatchEvent(
-      new CustomEvent('tabs-error', {
-        detail: {
-          error,
-          context,
-          timestamp: Date.now(),
-          controller: this.constructor.name
-        },
-        bubbles: true,
-        composed: true,
-      })
-    );
-  }
-
-  /**
-   * Helper method to dispatch events consistently
-   */
-  protected dispatchEvent(event: CustomEvent): void {
-    try {
-      this._host.dispatchEvent(event);
-    } catch (error) {
-      console.error('[TabsController] Failed to dispatch event:', error);
-    }
-  }
+export abstract class BaseTabsController extends BaseComponentController<TabsHost & ReactiveControllerHost>
+  implements TabsBaseController {
 
   /**
    * Helper method to check if tab is valid

--- a/src/components/tabs/controllers/dragdrop.controller.ts
+++ b/src/components/tabs/controllers/dragdrop.controller.ts
@@ -43,7 +43,7 @@ export class TabsDragDropController extends BaseTabsController implements DragDr
     this.dragOverHandler = (event: Event) => this.handleDragOver(event as DragEvent);
   }
 
-  override get host(): TabsDragDropHost {
+  override get host(): TabsDragDropHost & ReactiveControllerHost {
     return this._host;
   }
 

--- a/src/components/tabs/controllers/editable.controller.ts
+++ b/src/components/tabs/controllers/editable.controller.ts
@@ -40,7 +40,7 @@ export class TabsEditableController extends BaseTabsController implements Editab
     this._host = host;
   }
 
-  override get host(): TabsEditableHost {
+  override get host(): TabsEditableHost & ReactiveControllerHost {
     return this._host;
   }
 

--- a/src/components/tabs/controllers/event.controller.ts
+++ b/src/components/tabs/controllers/event.controller.ts
@@ -38,7 +38,7 @@ export class TabsEventController extends BaseTabsController implements EventCont
     this._host = host;
   }
 
-  override get host(): TabsEventHost {
+  override get host(): TabsEventHost & ReactiveControllerHost {
     return this._host;
   }
 

--- a/src/components/tabs/controllers/keyboard.controller.ts
+++ b/src/components/tabs/controllers/keyboard.controller.ts
@@ -39,7 +39,7 @@ export class TabsKeyboardController extends BaseTabsController implements Keyboa
     this.keyboardHandler = (event: Event) => this.handleKeyDown(event as KeyboardEvent);
   }
 
-  override get host(): TabsKeyboardHost {
+  override get host(): TabsKeyboardHost & ReactiveControllerHost {
     return this._host;
   }
 

--- a/src/components/textarea/controllers/base.controller.ts
+++ b/src/components/textarea/controllers/base.controller.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { ReactiveControllerHost } from 'lit';
+import { BaseComponentController } from '@nuralyui/common/controllers';
 
 /**
  * Base interface for textarea controllers
@@ -34,109 +35,15 @@ export interface TextareaHost extends EventTarget {
 }
 
 /**
- * Error handler interface for consistent error handling
- */
-export interface ErrorHandler {
-  handleError(error: Error, context: string): void;
-}
-
-/**
  * Abstract base controller class that implements common functionality
  * for all textarea component controllers
  */
-export abstract class BaseTextareaController implements TextareaBaseController, ReactiveController, ErrorHandler {
-  protected _host: TextareaHost & ReactiveControllerHost;
-
-  constructor(host: TextareaHost & ReactiveControllerHost) {
-    this._host = host;
-    this._host.addController(this);
-  }
+export abstract class BaseTextareaController extends BaseComponentController<TextareaHost & ReactiveControllerHost> {
 
   /**
-   * Get the host element
-   */
-  get host(): TextareaHost & ReactiveControllerHost {
-    return this._host;
-  }
-
-  /**
-   * Lifecycle: Host connected
-   */
-  hostConnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Lifecycle: Host disconnected
-   */
-  hostDisconnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Lifecycle: Host updated
-   */
-  hostUpdated(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Lifecycle: Host update complete
-   */
-  hostUpdate(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Handle errors consistently across controllers
-   */
-  handleError(error: Error, context: string): void {
-    console.error(`[${this.constructor.name}] Error in ${context}:`, error);
-    
-    // You could extend this to dispatch error events, log to analytics, etc.
-    const errorEvent = new CustomEvent('textarea-controller-error', {
-      detail: {
-        error: error.message,
-        context,
-        controller: this.constructor.name
-      },
-      bubbles: true,
-      composed: true
-    });
-    
-    this._host.dispatchEvent(errorEvent);
-  }
-
-  /**
-   * Safely execute a function with error handling
-   */
-  protected safeExecute<T>(fn: () => T, context: string, fallback?: T): T | undefined {
-    try {
-      return fn();
-    } catch (error) {
-      this.handleError(error as Error, context);
-      return fallback;
-    }
-  }
-
-  /**
-   * Request a host update safely
+   * Request a host update safely (alias for requestUpdate)
    */
   protected requestHostUpdate(): void {
-    this.safeExecute(() => this._host.requestUpdate(), 'requestHostUpdate');
-  }
-
-  /**
-   * Debounce utility for controllers
-   */
-  protected debounce<T extends (...args: any[]) => any>(
-    func: T,
-    wait: number
-  ): (...args: Parameters<T>) => void {
-    let timeout: ReturnType<typeof setTimeout>;
-    return (...args: Parameters<T>) => {
-      clearTimeout(timeout);
-      timeout = setTimeout(() => func.apply(this, args), wait);
-    };
+    this.requestUpdate();
   }
 }

--- a/src/components/textarea/textarea.component.ts
+++ b/src/components/textarea/textarea.component.ts
@@ -21,6 +21,7 @@ import {
   FocusOptions
 } from './textarea.types.js';
 import { NuralyUIBaseMixin } from '@nuralyui/common/mixins';
+import { renderClearButton, renderValidationIcon } from '@nuralyui/common/utils';
 import { ValidatableComponent, ValidationStatus } from '@nuralyui/common/mixins';
 import {
   TextareaValidationController,
@@ -188,7 +189,7 @@ export class NrTextareaElement extends NuralyUIBaseMixin(LitElement)
    */
   private setupControllerListeners(): void {
     // Validation events
-    this.addEventListener('textarea-validation', (e: any) => {
+    this.addEventListener('nr-validation', (e: any) => {
       this.validationResult = e.detail.validationResult;
     });
 
@@ -291,7 +292,7 @@ export class NrTextareaElement extends NuralyUIBaseMixin(LitElement)
     if (changedProperties.has('rules')) {
       this.validationController.clearValidation();
       if (this.rules.length > 0 && this.value) {
-        this.validationController.validate(this.value);
+        this.validationController.validateTextarea(this.value);
       }
     }
   }
@@ -460,7 +461,7 @@ export class NrTextareaElement extends NuralyUIBaseMixin(LitElement)
    * Trigger validation manually (ValidatableComponent interface)
    */
   async validate(): Promise<boolean> {
-    const result = await this.validationController.validate(this.value);
+    const result = await this.validationController.validateTextarea(this.value);
     return result.isValid;
   }
 
@@ -515,7 +516,7 @@ export class NrTextareaElement extends NuralyUIBaseMixin(LitElement)
    * Check if the textarea value is valid
    */
   isValid(): boolean {
-    return this.validationController.isValid();
+    return this.validationController.isCurrentlyValid();
   }
 
   // Form integration methods (FormFieldCapable interface)
@@ -524,17 +525,17 @@ export class NrTextareaElement extends NuralyUIBaseMixin(LitElement)
    * Check validity (HTML form API compatibility)
    */
   checkValidity(): boolean {
-    return this.validationController.isValid();
+    return this.validationController.isCurrentlyValid();
   }
 
   /**
    * Report validity (HTML form API compatibility)
    */
   reportValidity(): boolean {
-    const isValid = this.validationController.isValid();
+    const isValid = this.validationController.isCurrentlyValid();
     if (!isValid) {
       // Trigger validation to show error messages
-      this.validationController.validate(this.value);
+      this.validationController.validateTextarea(this.value);
     }
     return isValid;
   }
@@ -561,7 +562,7 @@ export class NrTextareaElement extends NuralyUIBaseMixin(LitElement)
    * Trigger validation manually (enhanced version)
    */
   async validateTextarea(): Promise<boolean> {
-    const result = await this.validationController.validate(this.value);
+    const result = await this.validationController.validateTextarea(this.value);
     return result.isValid;
   }
 
@@ -615,33 +616,21 @@ export class NrTextareaElement extends NuralyUIBaseMixin(LitElement)
   }
 
   private renderValidationIcon() {
-    if (!this.hasFeedback || !this.validationResult) return '';
-
-    const iconName = this.validationResult.level === 'error' ? 'error' :
-                     this.validationResult.level === 'warning' ? 'warning' : 'check-circle';
-
-    return html`
-      <nr-icon 
-        class="validation-icon ${this.validationResult.level}"
-        name="${iconName}"
-        size="small"
-      ></nr-icon>
-    `;
+    return renderValidationIcon(
+      this.validationResult?.level,
+      this.hasFeedback && !!this.validationResult,
+    );
   }
 
   private renderClearButton() {
-    if (!this.allowClear || !this.value || this.disabled || this.readonly) return '';
-
-    return html`
-      <button
-        class="clear-button"
-        type="button"
-        @click=${this.handleClear}
-        aria-label="Clear textarea"
-      >
-        <nr-icon name="x" size="small"></nr-icon>
-      </button>
-    `;
+    return renderClearButton({
+      allowClear: this.allowClear,
+      value: this.value,
+      disabled: this.disabled,
+      readonly: this.readonly,
+      onClear: this.handleClear,
+      ariaLabel: 'Clear textarea',
+    });
   }
 
   private renderCharacterCount() {

--- a/src/components/timepicker/timepicker.component.ts
+++ b/src/components/timepicker/timepicker.component.ts
@@ -6,6 +6,7 @@ import { INPUT_STATE } from '../input/input.types.js';
 
 // Import base mixin and types
 import { NuralyUIBaseMixin } from '@nuralyui/common/mixins';
+import { renderLabel as sharedRenderLabel } from '@nuralyui/common/utils';
 import { SharedDropdownController } from '@nuralyui/common/controllers';
 import { DropdownHost } from '@nuralyui/common/controllers';
 import {
@@ -220,14 +221,12 @@ export class NrTimePickerElement extends NuralyUIBaseMixin(LitElement) implement
 
   // Private methods
   private renderLabel(): TemplateResult | typeof nothing {
-    if (!this.label) return nothing;
-
-    return html`
-      <label class="time-picker__label" part="label" for="time-input">
-        ${this.label}
-        ${this.required ? html`<span class="time-picker__required">*</span>` : nothing}
-      </label>
-    `;
+    return sharedRenderLabel(this.label, this.required, {
+      cssClass: 'time-picker__label',
+      part: 'label',
+      forId: 'time-input',
+      requiredClass: 'time-picker__required',
+    });
   }
 
   private renderInput(): TemplateResult {

--- a/src/components/toast/controllers/base.controller.ts
+++ b/src/components/toast/controllers/base.controller.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { ReactiveControllerHost } from 'lit';
+import { BaseComponentController } from '@nuralyui/common/controllers';
 
 /**
  * Base interface for toast controllers
@@ -17,89 +18,5 @@ export interface ToastControllerHost extends ReactiveControllerHost {
 /**
  * Abstract base controller for toast component controllers
  */
-export abstract class BaseToastController implements ReactiveController {
-  protected _host: ToastControllerHost;
-
-  constructor(host: ToastControllerHost) {
-    this._host = host;
-    this._host.addController(this);
-  }
-
-  /**
-   * Get the host element
-   */
-  get host(): ToastControllerHost {
-    return this._host;
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host connects
-   */
-  hostConnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host disconnects
-   */
-  hostDisconnected(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called when host updates
-   */
-  hostUpdate(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Reactive controller lifecycle - called after host updates
-   */
-  hostUpdated(): void {
-    // Override in subclasses if needed
-  }
-
-  /**
-   * Handle errors in a consistent way across all controllers
-   */
-  protected handleError(error: Error, context: string): void {
-    console.error(`[ToastController:${this.constructor.name}] Error in ${context}:`, error);
-    
-    // Dispatch error event for external handling
-    this._host.dispatchEvent(
-      new CustomEvent('nr-toast-error', {
-        detail: {
-          error: error.message,
-          context,
-          controller: this.constructor.name,
-        },
-        bubbles: true,
-        composed: true,
-      })
-    );
-  }
-
-  /**
-   * Request host update safely
-   */
-  protected requestUpdate(): void {
-    try {
-      this._host.requestUpdate();
-    } catch (error) {
-      this.handleError(error as Error, 'requestUpdate');
-    }
-  }
-
-  /**
-   * Dispatch custom event safely
-   */
-  protected dispatchEvent(event: Event): boolean {
-    try {
-      return this._host.dispatchEvent(event);
-    } catch (error) {
-      this.handleError(error as Error, 'dispatchEvent');
-      return false;
-    }
-  }
+export abstract class BaseToastController extends BaseComponentController<ToastControllerHost> {
 }


### PR DESCRIPTION
## Summary
- Unified 12 nearly-identical `BaseController` classes into a single shared generic `BaseComponentController<THost>` in `packages/common`
- Extracted shared `BaseValidationController` for input, textarea, select, and radio-group validation controllers
- Created shared render utilities (`renderClearButton`, `renderLabel`, `renderValidationIcon`, `renderValidationMessage`, `renderHelperText`) used across textarea, select, colorpicker, and timepicker
- Standardized error events to `nr-controller-error` and validation events to `nr-validation` across all components

**Result:** 36 files changed, ~1050 lines added, ~1440 lines removed (net reduction of ~390 lines of duplicated code)

## New files
- `packages/common/src/shared/controllers/base.controller.ts` — Shared `BaseComponentController<THost>` generic
- `packages/common/src/shared/controllers/base-validation.controller.ts` — Shared `BaseValidationController<THost>`
- `packages/common/src/shared/render-utils.ts` — Shared render helper functions

## Components affected
button, canvas, collapse, colorpicker, dropdown, input, menu, radio-group, select, table, tabs, textarea, timepicker, toast

## Test plan
- [x] TypeScript compilation passes (zero non-test errors)
- [x] Dashboard loads correctly with Vite aliases (studio PR #119)
- [ ] Verify form components render correctly (input, textarea, select, radio-group)
- [ ] Verify validation works on input, textarea, select
- [ ] Verify clear button works on input, textarea, select
- [ ] Verify tabs drag-and-drop, keyboard navigation, and editable tabs
- [ ] Verify collapse accordion mode

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)