### PR TITLE
feat: add Document Generator workflow node to canvas UI

### DIFF
--- a/src/components/canvas/templates/config-panel/type-fields.ts
+++ b/src/components/canvas/templates/config-panel/type-fields.ts
@@ -45,6 +45,8 @@ import {
   // Web nodes
   renderWebSearchFields,
   renderWebCrawlFields,
+  // Document generation
+  renderDocumentGeneratorFields,
   // Storage nodes
   renderFileStorageFields,
   // RAG nodes
@@ -139,6 +141,10 @@ export function renderTypeFields(
 
     case WorkflowNodeType.WEB_CRAWL:
       return renderWebCrawlFields(config, onUpdate);
+
+    // Document generation
+    case WorkflowNodeType.DOCUMENT_GENERATOR:
+      return renderDocumentGeneratorFields(config, onUpdate);
 
     // Storage nodes
     case WorkflowNodeType.FILE_STORAGE:

--- a/src/components/canvas/templates/config-panel/workflow-node-fields/document-generator-fields.ts
+++ b/src/components/canvas/templates/config-panel/workflow-node-fields/document-generator-fields.ts
@@ -1,0 +1,147 @@
+/**
+ * @license
+ * Copyright 2024 Nuraly, Laabidi Aymen
+ * SPDX-License-Identifier: MIT
+ */
+
+import { html, TemplateResult } from 'lit';
+import { NodeConfiguration } from '../../../workflow-canvas.types.js';
+
+/**
+ * Render Document Generator node fields
+ *
+ * Backend expects:
+ * - templateId: UUID of the document template
+ * - data: Object with key-value pairs for template variables (supports expressions)
+ * - outputVariable: Variable name to store result
+ *
+ * Output:
+ * - success: boolean
+ * - fileUrl: URL path to download the generated file
+ * - fileName: Name of the generated file
+ * - templateId: ID of the template used
+ */
+export function renderDocumentGeneratorFields(
+  config: NodeConfiguration,
+  onUpdate: (key: string, value: unknown) => void
+): TemplateResult {
+  // Parse existing data entries for the key-value editor
+  const dataEntries: Array<{ key: string; value: string }> = [];
+  if (config.data && typeof config.data === 'object') {
+    for (const [key, value] of Object.entries(config.data as Record<string, unknown>)) {
+      dataEntries.push({ key, value: String(value ?? '') });
+    }
+  }
+
+  const updateDataEntry = (index: number, field: 'key' | 'value', newValue: string) => {
+    const entries = [...dataEntries];
+    entries[index] = { ...entries[index], [field]: newValue };
+    const data: Record<string, string> = {};
+    for (const entry of entries) {
+      if (entry.key) {
+        data[entry.key] = entry.value;
+      }
+    }
+    onUpdate('data', data);
+  };
+
+  const addDataEntry = () => {
+    const data: Record<string, string> = {};
+    for (const entry of dataEntries) {
+      if (entry.key) {
+        data[entry.key] = entry.value;
+      }
+    }
+    data[''] = '';
+    onUpdate('data', data);
+  };
+
+  const removeDataEntry = (index: number) => {
+    const entries = dataEntries.filter((_, i) => i !== index);
+    const data: Record<string, string> = {};
+    for (const entry of entries) {
+      if (entry.key) {
+        data[entry.key] = entry.value;
+      }
+    }
+    onUpdate('data', data);
+  };
+
+  return html`
+    <div class="config-section">
+      <div class="config-section-header">
+        <span class="config-section-title">Template</span>
+      </div>
+      <div class="config-field">
+        <label>Template ID</label>
+        <nr-input
+          value=${(config.templateId as string) || ''}
+          placeholder="Enter template UUID or \${variables.templateId}"
+          @nr-input=${(e: CustomEvent) => onUpdate('templateId', e.detail.value)}
+        ></nr-input>
+        <small class="field-hint">UUID of the uploaded .docx template. Supports expressions.</small>
+      </div>
+    </div>
+
+    <div class="config-section">
+      <div class="config-section-header">
+        <span class="config-section-title">Template Data</span>
+      </div>
+      <small class="field-hint" style="margin-bottom: 8px; display: block;">
+        Map template placeholders to values. Values support expressions like \${variables.name} or \${input.field}.
+      </small>
+
+      ${dataEntries.map(
+        (entry, index) => html`
+          <div class="config-field" style="display: flex; gap: 8px; align-items: center;">
+            <nr-input
+              value=${entry.key}
+              placeholder="Field name"
+              style="flex: 1;"
+              @nr-input=${(e: CustomEvent) => updateDataEntry(index, 'key', e.detail.value)}
+            ></nr-input>
+            <nr-input
+              value=${entry.value}
+              placeholder="Value or \${expression}"
+              style="flex: 1;"
+              @nr-input=${(e: CustomEvent) => updateDataEntry(index, 'value', e.detail.value)}
+            ></nr-input>
+            <nr-button
+              variant="ghost"
+              size="small"
+              @click=${() => removeDataEntry(index)}
+            >
+              <nr-icon name="trash-2" size="small"></nr-icon>
+            </nr-button>
+          </div>
+        `
+      )}
+
+      <div class="config-field">
+        <nr-button
+          variant="outline"
+          size="small"
+          @click=${addDataEntry}
+        >
+          <nr-icon name="plus" size="small"></nr-icon>
+          Add Field
+        </nr-button>
+      </div>
+    </div>
+
+    <div class="config-section">
+      <div class="config-section-header">
+        <span class="config-section-title">Output</span>
+      </div>
+      <div class="config-field">
+        <label>Output Variable</label>
+        <nr-input
+          value=${(config.outputVariable as string) || 'documentResult'}
+          placeholder="documentResult"
+          @nr-input=${(e: CustomEvent) => onUpdate('outputVariable', e.detail.value)}
+        ></nr-input>
+        <small class="field-hint">Access via \${variables.documentResult.fileUrl}</small>
+      </div>
+    </div>
+  `;
+}

--- a/src/components/canvas/templates/config-panel/workflow-node-fields/index.ts
+++ b/src/components/canvas/templates/config-panel/workflow-node-fields/index.ts
@@ -32,6 +32,8 @@ export { renderOcrFields } from './ocr-fields.js';
 // Web nodes
 export { renderWebSearchFields } from './web-search-fields.js';
 export { renderWebCrawlFields } from './web-crawl-fields.js';
+// Document generation
+export { renderDocumentGeneratorFields } from './document-generator-fields.js';
 // Storage nodes
 export { renderFileStorageFields } from './file-storage-fields.js';
 // RAG nodes

--- a/src/components/canvas/workflow-canvas.types.ts
+++ b/src/components/canvas/workflow-canvas.types.ts
@@ -37,6 +37,8 @@ export enum WorkflowNodeType {
   // Web nodes
   WEB_SEARCH = 'WEB_SEARCH',
   WEB_CRAWL = 'WEB_CRAWL',
+  // Document generation
+  DOCUMENT_GENERATOR = 'DOCUMENT_GENERATOR',
   // Storage nodes
   FILE_STORAGE = 'FILE_STORAGE',
   // RAG nodes
@@ -602,6 +604,8 @@ export const NODE_COLORS: Record<NodeType, string> = {
   // Web nodes
   [WorkflowNodeType.WEB_SEARCH]: '#3b82f6',
   [WorkflowNodeType.WEB_CRAWL]: '#6366f1',
+  // Document generation
+  [WorkflowNodeType.DOCUMENT_GENERATOR]: '#0284c7',
   // Storage nodes
   [WorkflowNodeType.FILE_STORAGE]: '#f59e0b',
   // RAG nodes
@@ -700,6 +704,8 @@ export const NODE_ICONS: Record<NodeType, string> = {
   // Web nodes
   [WorkflowNodeType.WEB_SEARCH]: 'search',
   [WorkflowNodeType.WEB_CRAWL]: 'globe',
+  // Document generation
+  [WorkflowNodeType.DOCUMENT_GENERATOR]: 'file-text',
   // Storage nodes
   [WorkflowNodeType.FILE_STORAGE]: 'hard-drive',
   // RAG nodes
@@ -1226,6 +1232,27 @@ export const NODE_TEMPLATES: NodeTemplate[] = [
       inputs: [{ id: 'in', type: PortType.INPUT, label: 'Input' }],
       outputs: [
         { id: 'out', type: PortType.OUTPUT, label: 'Pages' },
+        { id: 'error', type: PortType.ERROR, label: 'Error' },
+      ],
+    },
+  },
+  // Document generation
+  {
+    type: WorkflowNodeType.DOCUMENT_GENERATOR,
+    name: 'Document Generator',
+    description: 'Generate Word documents from templates with dynamic data',
+    icon: NODE_ICONS[WorkflowNodeType.DOCUMENT_GENERATOR],
+    color: NODE_COLORS[WorkflowNodeType.DOCUMENT_GENERATOR],
+    category: 'documents',
+    defaultConfig: {
+      templateId: '',
+      data: {},
+      outputVariable: 'documentResult',
+    },
+    defaultPorts: {
+      inputs: [{ id: 'in', type: PortType.INPUT, label: 'Input' }],
+      outputs: [
+        { id: 'out', type: PortType.OUTPUT, label: 'Result' },
         { id: 'error', type: PortType.ERROR, label: 'Error' },
       ],
     },


### PR DESCRIPTION
## Summary
- Add `DOCUMENT_GENERATOR` node type to `WorkflowNodeType` enum with color (`#0284c7`) and icon (`file-text`)
- Add node template with default config (templateId, data, outputVariable), input/output/error ports
- Create `document-generator-fields.ts` config panel with template ID input, dynamic key-value data mapping editor, and output variable config
- Wire up exports in `workflow-node-fields/index.ts` and routing in `type-fields.ts`

## Related
- Closes https://github.com/Nuralyio/studio/issues/205

## Test plan
- [ ] Verify Document Generator node appears in canvas node palette under "documents" category
- [ ] Verify node renders with correct color (#0284c7) and icon (file-text)
- [ ] Verify config panel shows Template ID, Template Data (key-value editor), and Output Variable fields
- [ ] Verify adding/removing data field entries works correctly
- [ ] Verify expression placeholders display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)